### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: csharp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/SonosStreaming.sln', 'csharp/Directory.Build.props', 'csharp/**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore SonosStreaming.sln
+
+      - name: Build
+        run: dotnet build SonosStreaming.sln -c Release --no-restore -warnaserror
+
+      - name: Test
+        run: dotnet test SonosStreaming.sln -c Release --no-build --logger "trx;LogFileName=tests.trx" --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: csharp/TestResults/**/*.trx
+          if-no-files-found: warn


### PR DESCRIPTION
Adds a Windows GitHub Actions workflow for .NET 9 restore, Release build with warnings as errors, tests with TRX output, and test-result artifact upload. Local validation: restore passed; build passed with 0 warnings/errors; tests passed, 74 passed.