### PR TITLE
Add manual Sonos endpoint fallback

### DIFF
--- a/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
+++ b/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Net;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Dispatching;
@@ -89,6 +90,15 @@ public sealed partial class MainViewModel : ObservableObject
     [ObservableProperty]
     public partial string EncoderLabel { get; set; }
 
+    [ObservableProperty]
+    public partial string ManualSpeakerIp { get; set; }
+
+    [ObservableProperty]
+    public partial string ManualSpeakerPort { get; set; }
+
+    [ObservableProperty]
+    public partial string ManualSpeakerStatus { get; set; }
+
     public StreamingFormat[] AvailableFormats { get; } = Enum.GetValues<StreamingFormat>();
     public string[] AvailableFormatNames { get; } = Enum.GetValues<StreamingFormat>().Select(f => f.DisplayName()).ToArray();
 
@@ -129,6 +139,9 @@ public sealed partial class MainViewModel : ObservableObject
         ErrorMessage = "";
         SelectedFormat = settings.StreamingFormat;
         EncoderLabel = settings.StreamingFormat.DisplayName();
+        ManualSpeakerIp = "";
+        ManualSpeakerPort = "1400";
+        ManualSpeakerStatus = "";
         Pipeline.Format = settings.StreamingFormat;
 
         // Apply persisted settings to pipeline stages so restart restores the
@@ -232,6 +245,18 @@ public sealed partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(SelectedFormatIndex));
     }
 
+    partial void OnManualSpeakerIpChanged(string value)
+    {
+        ManualSpeakerStatus = "";
+        AddManualSpeakerCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnManualSpeakerPortChanged(string value)
+    {
+        ManualSpeakerStatus = "";
+        AddManualSpeakerCommand.NotifyCanExecuteChanged();
+    }
+
     partial void OnSelectedProcessChanged(AudioProcess? value)
     {
         if (value != null)
@@ -302,25 +327,28 @@ public sealed partial class MainViewModel : ObservableObject
     [RelayCommand]
     public async Task RescanAsync()
     {
+        List<SonosDevice> raw = new();
         try
         {
-            var raw = await _discovery.ScanAsync(3000);
-            var resolved = await _topology.ResolveCoordinatorsAsync(raw);
-            Speakers.Clear();
-            foreach (var d in resolved) Speakers.Add(d);
-            _core.SetDiscovered(resolved);
-            Log.Information("Discovered {Count} speaker(s)", resolved.Count);
-
-            // Re-select the user's last speaker automatically if it's in range.
-            if (SelectedSpeaker == null && !string.IsNullOrEmpty(Settings.LastSpeakerUdn))
-            {
-                var match = resolved.FirstOrDefault(d => d.Udn == Settings.LastSpeakerUdn);
-                if (match != null) SelectSpeaker(match);
-            }
+            raw = await _discovery.ScanAsync(3000);
         }
         catch (Exception ex)
         {
             Log.Warning(ex, "SSDP scan failed");
+        }
+
+        var manual = await LookupSavedManualSpeakersAsync();
+        var mergedRaw = SsdpDiscovery.MergeDevices(raw, manual);
+        var resolved = await ResolveWithFallbackAsync(mergedRaw);
+        SyncSpeakers(resolved);
+        _core.SetDiscovered(resolved);
+        Log.Information("Discovered {Count} speaker(s)", resolved.Count);
+
+        // Re-select the user's last speaker automatically if it's in range.
+        if (SelectedSpeaker == null && !string.IsNullOrEmpty(Settings.LastSpeakerUdn))
+        {
+            var match = resolved.FirstOrDefault(d => d.Udn == Settings.LastSpeakerUdn);
+            if (match != null) SelectSpeaker(match);
         }
 
         try
@@ -332,6 +360,42 @@ public sealed partial class MainViewModel : ObservableObject
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to enumerate audio processes");
+        }
+    }
+
+    public bool CanAddManualSpeaker => StateLabel == "Idle";
+
+    [RelayCommand(CanExecute = nameof(CanAddManualSpeaker))]
+    public async Task AddManualSpeakerAsync()
+    {
+        if (!TryParseManualEndpoint(ManualSpeakerIp, ManualSpeakerPort, out var ip, out var port, out var error))
+        {
+            ManualSpeakerStatus = error;
+            return;
+        }
+
+        try
+        {
+            ManualSpeakerStatus = "Looking up speaker...";
+            var direct = await _discovery.LookupAsync(ip, port);
+            var resolved = await ResolveWithFallbackAsync([direct]);
+            var merged = SsdpDiscovery.MergeDevices(Speakers, resolved);
+            SyncSpeakers(merged);
+            _core.SetDiscovered(merged);
+
+            AddSavedManualEndpoint(ip, port);
+
+            var selected = FindMatchingSpeaker(resolved.First(), merged) ?? resolved.First();
+            SelectSpeaker(selected);
+
+            ManualSpeakerIp = "";
+            ManualSpeakerPort = "1400";
+            ManualSpeakerStatus = $"Added {selected.FriendlyName}";
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Manual speaker lookup failed for {Ip}:{Port}", ip, port);
+            ManualSpeakerStatus = $"Could not reach {ip}:{port}";
         }
     }
 
@@ -372,7 +436,9 @@ public sealed partial class MainViewModel : ObservableObject
     {
         StartCommand.NotifyCanExecuteChanged();
         StopCommand.NotifyCanExecuteChanged();
+        AddManualSpeakerCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(IsNotStreaming));
+        OnPropertyChanged(nameof(CanAddManualSpeaker));
         StatusBrush = value switch
         {
             "Streaming" => new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.LimeGreen),
@@ -380,6 +446,100 @@ public sealed partial class MainViewModel : ObservableObject
             _ => new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
         };
     }
+
+    private async Task<List<SonosDevice>> LookupSavedManualSpeakersAsync()
+    {
+        var devices = new List<SonosDevice>();
+        foreach (var endpoint in Settings.ManualSpeakerEndpoints)
+        {
+            if (!IPAddress.TryParse(endpoint.Ip, out var ip))
+            {
+                Log.Warning("Skipping invalid saved manual speaker endpoint {Ip}:{Port}", endpoint.Ip, endpoint.Port);
+                continue;
+            }
+
+            try
+            {
+                devices.Add(await _discovery.LookupAsync(ip, endpoint.Port));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Saved manual speaker lookup failed for {Ip}:{Port}", endpoint.Ip, endpoint.Port);
+            }
+        }
+
+        return devices;
+    }
+
+    private async Task<List<SonosDevice>> ResolveWithFallbackAsync(List<SonosDevice> devices)
+    {
+        try
+        {
+            var resolved = await _topology.ResolveCoordinatorsAsync(devices);
+            return resolved.Count == 0 && devices.Count > 0 ? devices : resolved;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Topology resolution failed; keeping directly discovered speaker(s)");
+            return devices;
+        }
+    }
+
+    private static bool TryParseManualEndpoint(
+        string ipText,
+        string portText,
+        out IPAddress ip,
+        out ushort port,
+        out string error)
+    {
+        ip = IPAddress.None;
+        port = 1400;
+        error = "";
+
+        if (!IPAddress.TryParse(ipText.Trim(), out ip!))
+        {
+            error = "Enter a valid IP address.";
+            return false;
+        }
+
+        var trimmedPort = portText.Trim();
+        if (string.IsNullOrEmpty(trimmedPort))
+        {
+            port = 1400;
+            return true;
+        }
+
+        if (!ushort.TryParse(trimmedPort, out port) || port == 0)
+        {
+            error = "Enter a port from 1 to 65535.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private void SyncSpeakers(List<SonosDevice> devices)
+    {
+        Speakers.Clear();
+        foreach (var d in devices) Speakers.Add(d);
+    }
+
+    private void AddSavedManualEndpoint(IPAddress ip, ushort port)
+    {
+        var ipText = ip.ToString();
+        if (Settings.ManualSpeakerEndpoints.Any(e =>
+                e.Port == port &&
+                string.Equals(e.Ip, ipText, StringComparison.OrdinalIgnoreCase)))
+            return;
+
+        Settings.ManualSpeakerEndpoints.Add(new ManualSpeakerEndpoint { Ip = ipText, Port = port });
+        Settings.Save();
+    }
+
+    private static SonosDevice? FindMatchingSpeaker(SonosDevice device, IEnumerable<SonosDevice> candidates) =>
+        candidates.FirstOrDefault(candidate =>
+            string.Equals(candidate.Udn, device.Udn, StringComparison.OrdinalIgnoreCase) ||
+            candidate.Ip.Equals(device.Ip) && candidate.Port == device.Port);
 
     partial void OnSelectedSpeakerChanged(SonosDevice? value)
     {

--- a/csharp/src/SonosStreaming.App/Views/MainPage.xaml
+++ b/csharp/src/SonosStreaming.App/Views/MainPage.xaml
@@ -79,6 +79,41 @@
                                 </StackPanel>
                             </Grid>
                         </Button>
+                        <Grid ColumnSpacing="8" Margin="0,4,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="72" />
+                            </Grid.ColumnDefinitions>
+                            <TextBox
+                                Header="IP address"
+                                PlaceholderText="192.168.1.50"
+                                Text="{x:Bind ViewModel.ManualSpeakerIp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                IsEnabled="{x:Bind ViewModel.CanAddManualSpeaker, Mode=OneWay}" />
+                            <TextBox
+                                Grid.Column="1"
+                                Header="Port"
+                                Text="{x:Bind ViewModel.ManualSpeakerPort, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                IsEnabled="{x:Bind ViewModel.CanAddManualSpeaker, Mode=OneWay}"
+                                MaxLength="5" />
+                        </Grid>
+                        <Button HorizontalAlignment="Stretch" Command="{x:Bind ViewModel.AddManualSpeakerCommand}">
+                            <Grid HorizontalAlignment="Center">
+                                <StackPanel Orientation="Horizontal" Spacing="6"
+                                    Visibility="{x:Bind ViewModel.AddManualSpeakerCommand.IsRunning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverse}">
+                                    <FontIcon Glyph="&#xE710;" FontSize="14" />
+                                    <TextBlock Text="Add manual speaker" VerticalAlignment="Center" />
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" Spacing="8"
+                                    Visibility="{x:Bind ViewModel.AddManualSpeakerCommand.IsRunning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <ProgressRing IsActive="True" Width="14" Height="14" />
+                                    <TextBlock Text="Adding..." VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Grid>
+                        </Button>
+                        <TextBlock
+                            Text="{x:Bind ViewModel.ManualSpeakerStatus, Mode=OneWay}"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap" />
                     </StackPanel>
                 </Border>
 

--- a/csharp/src/SonosStreaming.Core/Network/ISsdpDiscovery.cs
+++ b/csharp/src/SonosStreaming.Core/Network/ISsdpDiscovery.cs
@@ -1,6 +1,9 @@
+using System.Net;
+
 namespace SonosStreaming.Core.Network;
 
 public interface ISsdpDiscovery : IDisposable
 {
     Task<List<SonosDevice>> ScanAsync(int timeoutMs = 3000, CancellationToken ct = default);
+    Task<SonosDevice> LookupAsync(IPAddress ip, ushort port = 1400, CancellationToken ct = default);
 }

--- a/csharp/src/SonosStreaming.Core/Network/SsdpDiscovery.cs
+++ b/csharp/src/SonosStreaming.Core/Network/SsdpDiscovery.cs
@@ -81,6 +81,9 @@ public sealed class SsdpDiscovery : ISsdpDiscovery
         return (ip4, port4);
     }
 
+    public static string FormatHost(IPAddress ip) =>
+        ip.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{ip}]" : ip.ToString();
+
     public static (string FriendlyName, string Udn)? ParseDeviceDescription(string xml)
     {
         var name = ExtractElement(xml, "friendlyName");
@@ -99,6 +102,41 @@ public sealed class SsdpDiscovery : ISsdpDiscovery
         int end = xml.IndexOf(close, start, StringComparison.OrdinalIgnoreCase);
         if (end < 0) return null;
         return xml[start..end].Trim();
+    }
+
+    public async Task<SonosDevice> LookupAsync(IPAddress ip, ushort port = 1400, CancellationToken ct = default)
+    {
+        var url = $"http://{FormatHost(ip)}:{port}/xml/device_description.xml";
+        var resp = await _http.GetStringAsync(url, ct).ConfigureAwait(false);
+        var desc = ParseDeviceDescription(resp);
+        if (desc == null)
+            throw new InvalidOperationException($"Device description from {ip}:{port} did not contain a Sonos friendlyName and UDN.");
+
+        return new SonosDevice(desc.Value.FriendlyName, ip, port, desc.Value.Udn);
+    }
+
+    public static List<SonosDevice> MergeDevices(IEnumerable<SonosDevice> primary, IEnumerable<SonosDevice> fallback)
+    {
+        var merged = new List<SonosDevice>();
+        foreach (var device in primary.Concat(fallback))
+        {
+            if (merged.Any(existing => IsSameDevice(existing, device)))
+                continue;
+
+            merged.Add(device);
+        }
+
+        return merged;
+    }
+
+    private static bool IsSameDevice(SonosDevice left, SonosDevice right)
+    {
+        if (!string.IsNullOrWhiteSpace(left.Udn) &&
+            !string.IsNullOrWhiteSpace(right.Udn) &&
+            string.Equals(left.Udn, right.Udn, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return left.Ip.Equals(right.Ip) && left.Port == right.Port;
     }
 
     public async Task<List<SonosDevice>> ScanAsync(int timeoutMs = 3000, CancellationToken ct = default)
@@ -245,5 +283,5 @@ public sealed class SsdpDiscovery : ISsdpDiscovery
 
 public sealed record SonosDevice(string FriendlyName, IPAddress Ip, ushort Port, string Udn)
 {
-    public string AvTransportControlUrl => $"http://{Ip}:{Port}/MediaRenderer/AVTransport/Control";
+    public string AvTransportControlUrl => $"http://{SsdpDiscovery.FormatHost(Ip)}:{Port}/MediaRenderer/AVTransport/Control";
 }

--- a/csharp/src/SonosStreaming.Core/State/AppSettings.cs
+++ b/csharp/src/SonosStreaming.Core/State/AppSettings.cs
@@ -33,6 +33,7 @@ public sealed class AppSettings : IDisposable
     public float DelayMsR { get; set; } = 0.0f;
     public string? LastSpeakerUdn { get; set; }
     public StreamingFormat StreamingFormat { get; set; } = StreamingFormat.Aac256;
+    public List<ManualSpeakerEndpoint> ManualSpeakerEndpoints { get; set; } = new();
 
     public AppSettings()
     {
@@ -45,7 +46,9 @@ public sealed class AppSettings : IDisposable
         {
             if (!File.Exists(SettingsPath)) return new AppSettings();
             var json = File.ReadAllText(SettingsPath);
-            return JsonSerializer.Deserialize<AppSettings>(json, JsonOpts) ?? new AppSettings();
+            var settings = JsonSerializer.Deserialize<AppSettings>(json, JsonOpts) ?? new AppSettings();
+            settings.ManualSpeakerEndpoints ??= [];
+            return settings;
         }
         catch (Exception ex)
         {
@@ -88,4 +91,10 @@ public sealed class AppSettings : IDisposable
         _saveDebounceTimer.Dispose();
         FlushSave();
     }
+}
+
+public sealed record ManualSpeakerEndpoint
+{
+    public string Ip { get; init; } = "";
+    public ushort Port { get; init; } = 1400;
 }

--- a/csharp/tests/SonosStreaming.Tests/AppSettingsTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/AppSettingsTests.cs
@@ -50,7 +50,12 @@ public class AppSettingsTests : IDisposable
             EqHighDb = 1.5f,
             DelayMsL = 10.0f,
             DelayMsR = 5.0f,
-            LastSpeakerUdn = "uuid:test-speaker"
+            LastSpeakerUdn = "uuid:test-speaker",
+            ManualSpeakerEndpoints =
+            [
+                new ManualSpeakerEndpoint { Ip = "192.168.1.50", Port = 1400 },
+                new ManualSpeakerEndpoint { Ip = "192.168.1.51", Port = 1500 },
+            ]
         };
 
         original.Save();
@@ -67,6 +72,7 @@ public class AppSettingsTests : IDisposable
         loaded.DelayMsL.Should().Be(10.0f);
         loaded.DelayMsR.Should().Be(5.0f);
         loaded.LastSpeakerUdn.Should().Be("uuid:test-speaker");
+        loaded.ManualSpeakerEndpoints.Should().BeEquivalentTo(original.ManualSpeakerEndpoints);
     }
 
     [Fact]

--- a/csharp/tests/SonosStreaming.Tests/SsdpParserTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/SsdpParserTests.cs
@@ -1,6 +1,8 @@
 using SonosStreaming.Core.Network;
 using FluentAssertions;
 using Xunit;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 
 namespace SonosStreaming.Tests;
@@ -49,5 +51,66 @@ public class SsdpParserTests
         desc.Should().NotBeNull();
         desc!.Value.FriendlyName.Should().Be("Kitchen - Sonos Play:1");
         desc.Value.Udn.Should().Be("uuid:RINCON_AABBCCDDEEFF01400");
+    }
+
+    [Fact]
+    public async Task LookupAsync_FetchesDeviceDescriptionFromCustomPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = (ushort)((IPEndPoint)listener.LocalEndpoint).Port;
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            await using var stream = client.GetStream();
+            var buffer = new byte[2048];
+            _ = await stream.ReadAsync(buffer);
+
+            var xml = "<?xml version=\"1.0\"?><root><device><friendlyName>Office</friendlyName><UDN>uuid:RINCON_TEST01400</UDN></device></root>";
+            var body = Encoding.UTF8.GetBytes(xml);
+            var header = Encoding.ASCII.GetBytes(
+                "HTTP/1.1 200 OK\r\n" +
+                $"Content-Length: {body.Length}\r\n" +
+                "Content-Type: text/xml\r\n\r\n");
+            await stream.WriteAsync(header);
+            await stream.WriteAsync(body);
+        });
+
+        using var discovery = new SsdpDiscovery();
+        var device = await discovery.LookupAsync(IPAddress.Loopback, port);
+
+        device.FriendlyName.Should().Be("Office");
+        device.Udn.Should().Be("uuid:RINCON_TEST01400");
+        device.Ip.Should().Be(IPAddress.Loopback);
+        device.Port.Should().Be(port);
+        await serverTask;
+    }
+
+    [Fact]
+    public void MergeDevices_DeduplicatesByUdnAndEndpoint()
+    {
+        var ssdp = new[]
+        {
+            new SonosDevice("Kitchen", IPAddress.Parse("192.168.1.10"), 1400, "uuid:RINCON_A"),
+            new SonosDevice("Office", IPAddress.Parse("192.168.1.11"), 1400, "uuid:RINCON_B"),
+        };
+        var manual = new[]
+        {
+            new SonosDevice("Kitchen duplicate", IPAddress.Parse("192.168.1.99"), 1400, "uuid:RINCON_A"),
+            new SonosDevice("Office duplicate", IPAddress.Parse("192.168.1.11"), 1400, "uuid:OTHER"),
+            new SonosDevice("Bedroom", IPAddress.Parse("192.168.1.12"), 1500, "uuid:RINCON_C"),
+        };
+
+        var merged = SsdpDiscovery.MergeDevices(ssdp, manual);
+
+        merged.Should().HaveCount(3);
+        merged.Select(d => d.FriendlyName).Should().Equal("Kitchen", "Office", "Bedroom");
+    }
+
+    [Fact]
+    public void FormatHost_BracketsIpv6Addresses()
+    {
+        SsdpDiscovery.FormatHost(IPAddress.Parse("fe80::1")).Should().Be("[fe80::1]");
+        SsdpDiscovery.FormatHost(IPAddress.Parse("192.168.1.42")).Should().Be("192.168.1.42");
     }
 }


### PR DESCRIPTION
## Summary
- add direct Sonos lookup by IP and optional port for networks where SSDP discovery fails
- persist manual endpoints and retry them during rescans without deleting failed saved entries
- add Speakers panel controls for manual IP/port entry with validation and coordinator-resolution fallback
- cover custom-port lookup, settings round trip, IPv6 host formatting, and discovery/manual dedupe in tests

## Verification
- dotnet test csharp\\SonosStreaming.sln -c Release
- dotnet build csharp\\SonosStreaming.sln -c Release