### PR TITLE
v1.0.4: Bug fixes, SSDP filtering, per-app UX, track metadata, UI polish

### DIFF
--- a/csharp/AGENTS.md
+++ b/csharp/AGENTS.md
@@ -343,10 +343,50 @@ WASAPI capture thread → PcmFrameF32 → DSP (gain → EQ → delay → volume 
     flowing via SetAVTransportURI.
 
 30. **Sonos HTTP client timeout.** `SonosController` uses a 30 s
-    `HttpClient.Timeout` (was 10 s). For WAV streams Sonos may buffer
-    several seconds of PCM before responding to SOAP Play, so the
-    shorter timeout caused pipeline teardowns that killed working
-    streams.
+     `HttpClient.Timeout` (was 10 s). For WAV streams Sonos may buffer
+     several seconds of PCM before responding to SOAP Play, so the
+     shorter timeout caused pipeline teardowns that killed working
+     streams.
+
+31. **SSDP UDN filtering.** `SsdpDiscovery` rejects devices whose UDN
+    doesn't start with `uuid:RINCON_`. This prevents non-Sonos UPnP
+    devices (Hue bridges, etc.) from appearing in the speaker list.
+    `LookupAsync` (Add by IP) throws `InvalidOperationException` for
+    non-Sonos UDNs. The `ScanAsync` path silently skips them.
+
+32. **Per-application capture enumerates only user-facing processes.**
+    `EnumerateActiveAudioProcesses` filters out the RoomRelay process
+    itself, system services (`svchost`, `dllhost`, etc.), shell/terminal
+    windows, browsers (which fail loopback), and anything under
+    `C:\Windows`. Only processes with a visible window, a window title,
+    or a known media player name are shown. Expired sessions are
+    excluded; inactive sessions are included so users can
+    pre-select before playback starts.
+
+33. **Process loopback COM errors are user-friendly.** Both the
+    `InvalidCastException` (E_NOINTERFACE on `IAudioClient`) during
+    activation and during `Initialize` are caught and rethrown as
+    `InvalidOperationException` with guidance to switch to "Whole system"
+    mode. The pipeline wraps the error again with the app name and PID.
+
+34. **Spectrum analyzer runs before all DSP stages.** The visualizer
+    reflects the input signal before gain, EQ, and volume are applied,
+    so it shows a consistent view regardless of user slider positions.
+
+35. **Sonos track title via DIDL-Lite metadata.** `BuildSetUriEnvelope`
+    accepts an optional `metadataTitle`. When provided, the
+    `CurrentURIMetaData` element contains a DIDL-Lite document with
+    `dc:title` set to `"RoomRelay — {FriendlyName}"`, so Sonos
+    displays the room name instead of a random stream filename.
+
+36. **Speaker list is disabled during streaming.** The `ListView` is
+    bound to `IsNotStreaming` so accidental re-selection mid-stream
+    can't desync the UI from the core state. `OnSelectedSpeakerChanged`
+    reverts the selection if `SetSpeaker` throws.
+
+37. **MenuBar replaced with flyout button.** The top menu bar was
+    replaced by a subtle overflow button with a `MenuFlyout`,
+    matching the card-based UI. Commands bind directly to VM commands.
 
 ## Testing pattern
 

--- a/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
+++ b/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
@@ -416,7 +416,7 @@ public sealed partial class MainViewModel : ObservableObject
         Log.Information("Discovered {Count} speaker(s)", resolved.Count);
 
         // Re-select by identity because the collection is rebuilt on every scan.
-        if (!string.IsNullOrEmpty(previousUdn))
+        if (!string.IsNullOrEmpty(previousUdn) && IsNotStreaming)
         {
             var match = resolved.FirstOrDefault(d => string.Equals(d.Udn, previousUdn, StringComparison.OrdinalIgnoreCase));
             if (match != null) SelectedSpeaker = match;
@@ -624,7 +624,12 @@ public sealed partial class MainViewModel : ObservableObject
                 Settings.LastSpeakerUdn = value.Udn;
                 Settings.Save();
             }
-            catch (Exception ex) { Log.Warning(ex, "Cannot select speaker"); }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Cannot select speaker; reverting");
+                SelectedSpeaker = _core.Selection.Speaker;
+                return;
+            }
             _ = RefreshSonosVolumeAsync();
         }
     }

--- a/csharp/src/SonosStreaming.App/Views/MainPage.xaml
+++ b/csharp/src/SonosStreaming.App/Views/MainPage.xaml
@@ -42,15 +42,22 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <MenuBar Grid.Row="0" Grid.ColumnSpan="3" Margin="0,0,0,10">
-            <MenuBarItem Title="File">
-                <MenuFlyoutItem Text="Open logs folder" Click="OpenLogsMenuItem_Click" />
-                <MenuFlyoutItem Text="Create diagnostics package" Click="CreateDiagnosticsMenuItem_Click" />
-            </MenuBarItem>
-            <MenuBarItem Title="Help">
-                <MenuFlyoutItem Text="About RoomRelay" Click="AboutMenuItem_Click" />
-            </MenuBarItem>
-        </MenuBar>
+        <Button Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Top"
+                Background="Transparent" BorderThickness="0"
+                ToolTipService.ToolTip="Tools"
+                Margin="0,-4,0,0">
+            <Button.Content>
+                <FontIcon Glyph="&#xE712;" FontSize="16" />
+            </Button.Content>
+            <Button.Flyout>
+                <MenuFlyout Placement="BottomEdgeAlignedRight">
+                    <MenuFlyoutItem Text="Open logs folder" Command="{x:Bind ViewModel.OpenLogsFolderCommand}" />
+                    <MenuFlyoutItem Text="Create diagnostics package" Command="{x:Bind ViewModel.CreateDiagnosticsPackageCommand}" />
+                    <MenuFlyoutSeparator />
+                    <MenuFlyoutItem Text="About RoomRelay" Click="AboutMenuItem_Click" />
+                </MenuFlyout>
+            </Button.Flyout>
+        </Button>
 
         <!-- Left panel -->
         <ScrollViewer Grid.Row="1" Grid.Column="0" VerticalScrollMode="Auto">
@@ -74,6 +81,7 @@
                             DisplayMemberPath="FriendlyName"
                             MaxHeight="180"
                             SelectionMode="Single"
+                            IsEnabled="{x:Bind ViewModel.IsNotStreaming, Mode=OneWay}"
                             Background="{x:Null}"
                             BorderThickness="0" />
                         <TextBlock

--- a/csharp/src/SonosStreaming.App/Views/MainPage.xaml.cs
+++ b/csharp/src/SonosStreaming.App/Views/MainPage.xaml.cs
@@ -36,16 +36,6 @@ public sealed partial class MainPage : Page
         ViewModel.IsErrorVisible = false;
     }
 
-    private void OpenLogsMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        ViewModel.OpenLogsFolderCommand.Execute(null);
-    }
-
-    private async void CreateDiagnosticsMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        await ViewModel.CreateDiagnosticsPackageCommand.ExecuteAsync(null);
-    }
-
     private async void AboutMenuItem_Click(object sender, RoutedEventArgs e)
     {
         var dialog = new ContentDialog

--- a/csharp/src/SonosStreaming.Core/Audio/ProcessLoopbackSource.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/ProcessLoopbackSource.cs
@@ -77,13 +77,23 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
         };
 
         const long hnsBufferDuration = 2_000_000L;
-        client.Initialize(
-            AUDCLNT_SHAREMODE.AUDCLNT_SHAREMODE_SHARED,
-            AUDCLNT_STREAMFLAGS_LOOPBACK | AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-            hnsBufferDuration,
-            0,
-            &wfx,
-            null);
+        try
+        {
+            client.Initialize(
+                AUDCLNT_SHAREMODE.AUDCLNT_SHAREMODE_SHARED,
+                AUDCLNT_STREAMFLAGS_LOOPBACK | AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+                hnsBufferDuration,
+                0,
+                &wfx,
+                null);
+        }
+        catch (InvalidCastException ice) when (ice.Message.Contains("IAudioClient"))
+        {
+            throw new InvalidOperationException(
+                $"This application (pid={_pid}) cannot be captured per-application. "
+                + "Browsers, system apps, and protected/elevated processes are not supported by Windows process loopback. "
+                + "Switch to 'Whole system' capture mode instead.", ice);
+        }
 
         BeginCapture(client, &wfx, $"ProcessLoopback-{_pid}");
         Log.Information("Process loopback capture started for pid={Pid} mode={Mode}", _pid, _mode);
@@ -124,12 +134,25 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                         int qi = Marshal.QueryInterface(pUnk, in iid, out var pAudioClient);
                         if (qi >= 0 && pAudioClient != IntPtr.Zero)
                         {
-                            result = (WinAudioClient)Marshal.GetObjectForIUnknown(pAudioClient);
+                            try
+                            {
+                                result = (WinAudioClient)Marshal.GetObjectForIUnknown(pAudioClient);
+                            }
+                            catch (InvalidCastException ice)
+                            {
+                                resultHr = unchecked((int)0x80004002); // E_NOINTERFACE
+                                Log.Warning(ice, "Process loopback cast to IAudioClient failed for pid={Pid}. " +
+                                    "The process ({Name}) may be a protected/system process. " +
+                                    "Try 'Whole system' mode instead.", _pid, _pid);
+                            }
                             Marshal.Release(pAudioClient);
                         }
                         else if (qi < 0)
                         {
                             resultHr = qi;
+                            Log.Warning("Process loopback QueryInterface failed for pid={Pid}: 0x{Hr:X8}. " +
+                                "The process may not have an active audio session, or it may be protected/elevated. " +
+                                "Try 'Whole system' mode instead.", _pid, qi);
                         }
                     }
                     finally { Marshal.Release(pUnk); }
@@ -156,8 +179,11 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                 throw new TimeoutException("Process loopback activation timed out after 10 seconds.");
             if (resultHr < 0)
             {
-                Log.Warning("Process loopback activation failed for pid={Pid}: 0x{Hr:X8}", _pid, resultHr);
-                throw Marshal.GetExceptionForHR(resultHr) ?? new Exception($"Process loopback activation failed: 0x{resultHr:X8}");
+                var msg = $"Process loopback activation failed for pid={_pid}: 0x{resultHr:X8}. "
+                    + "The application may not have an active audio session, or it may be protected/elevated. "
+                    + "Try 'Whole system' capture mode instead.";
+                Log.Warning(msg);
+                throw new InvalidOperationException(msg);
             }
             if (result == null)
                 throw new InvalidOperationException("Process loopback activation produced no IAudioClient");
@@ -250,6 +276,7 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                                             AudioSessionState state;
                                             session.GetState(&state);
                                             if (state == AudioSessionState.AudioSessionStateExpired) { expiredSkipped++; continue; }
+                                            if (pid == Environment.ProcessId) { continue; }
 
                                             string? sessionName = null;
                                             try
@@ -265,6 +292,11 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                                             catch { }
 
                                             var (processName, friendlyName) = GetProcessLabels(pid);
+                                            if (!IsUserFacingProcess(pid, processName))
+                                            {
+                                                systemPidSkipped++;
+                                                continue;
+                                            }
                                             string displayName = !string.IsNullOrEmpty(sessionName)
                                                 ? sessionName
                                                 : (friendlyName ?? processName ?? $"pid {pid}");
@@ -294,6 +326,63 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
         Log.Debug("Audio sessions: {Endpoints} endpoints, {Total} total sessions, {SysSkip} system, {ExpSkip} expired, {Kept} kept",
             endpointsScanned, totalSessions, systemPidSkipped, expiredSkipped, deduped.Count);
         return deduped;
+    }
+
+    private static readonly string[] SystemProcessNames = new[]
+    {
+        // Windows core
+        "svchost", "csrss", "smss", "services", "lsass", "wininit", "winlogon",
+        "dwm", "fontdrvhost", "conhost", "sihost", "taskhostw", "backgroundtaskhost",
+        "runtimebroker", "dllhost", "wmiprvse", "searchindexer", "securityhealthservice",
+        "ctfmon", "spoolsv", "audiodg", "musnotify", "wlanext", "vpnclient",
+        "searchhost", "textinputhost", "shellexperiencehost", "startmenuexperiencehost",
+        // Terminals / shells
+        "windowsterminal", "wt", "cmd", "powershell", "pwsh",
+        // IDEs / dev tools
+        "devenv", "code",
+        // Other background
+        "onedrive", "teams", "outlook",
+        // Browsers (loopback fails on most)
+        "msedge", "chrome", "firefox", "opera", "brave", "vivaldi"
+    };
+
+    private static bool IsUserFacingProcess(int pid, string? processName)
+    {
+        if (string.IsNullOrEmpty(processName)) return false;
+        if (SystemProcessNames.Contains(processName, StringComparer.OrdinalIgnoreCase)) return false;
+
+        try
+        {
+            using var proc = Process.GetProcessById(pid);
+
+            // If the executable lives under C:\Windows it's a system component.
+            try
+            {
+                var path = proc.MainModule?.FileName;
+                if (!string.IsNullOrEmpty(path))
+                {
+                    var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+                    if (path.StartsWith(windows, StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
+            catch { /* Access denied to MainModule for protected processes — fall through */ }
+
+            // A user-facing app typically has a visible main window.
+            if (proc.MainWindowHandle != IntPtr.Zero) return true;
+
+            // Some legitimate media apps hide their main window when minimized to tray.
+            if (!string.IsNullOrWhiteSpace(proc.MainWindowTitle)) return true;
+
+            var knownMediaPlayers = new[] { "spotify", "foobar2000", "musicbee", "aimp", "vlc", "winamp", "mediamonkey", "groove" };
+            if (knownMediaPlayers.Contains(processName, StringComparer.OrdinalIgnoreCase)) return true;
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static (string? processName, string? friendlyName) GetProcessLabels(int pid)

--- a/csharp/src/SonosStreaming.Core/Network/SonosController.cs
+++ b/csharp/src/SonosStreaming.Core/Network/SonosController.cs
@@ -14,20 +14,35 @@ public sealed class SonosController : ISonosController
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
     }
 
-    public static string BuildSetUriEnvelope(string streamUrl, bool useRadioScheme = true)
+    public static string BuildSetUriEnvelope(string streamUrl, bool useRadioScheme = true, string? metadataTitle = null)
     {
         var escaped = XmlEscape(streamUrl);
         // x-rincon-mp3radio:// forces Sonos into its MPEG radio decoder.
         // For LPCM (audio/L16) we send the plain http:// URI so Sonos
         // respects the Content-Type header and picks the PCM decoder.
         var currentUri = useRadioScheme ? $"x-rincon-mp3radio://{escaped}" : escaped;
+
+        var metadata = "";
+        if (!string.IsNullOrEmpty(metadataTitle))
+        {
+            var safeTitle = XmlEscape(metadataTitle);
+            var didl = $"<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" " +
+                       $"xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+                       $"xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\">" +
+                       $"<item id=\"-1\" parentID=\"-1\" restricted=\"true\">" +
+                       $"<dc:title>{safeTitle}</dc:title>" +
+                       $"<upnp:class>object.item.audioItem.audioBroadcast</upnp:class>" +
+                       $"</item></DIDL-Lite>";
+            metadata = XmlEscape(didl);
+        }
+
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" +
                "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n" +
                " <s:Body>\r\n" +
                $"  <u:SetAVTransportURI xmlns:u=\"{SoapNsAvTransport}\">\r\n" +
                "   <InstanceID>0</InstanceID>\r\n" +
                $"   <CurrentURI>{currentUri}</CurrentURI>\r\n" +
-               "   <CurrentURIMetaData></CurrentURIMetaData>\r\n" +
+               $"   <CurrentURIMetaData>{metadata}</CurrentURIMetaData>\r\n" +
                "  </u:SetAVTransportURI>\r\n" +
                " </s:Body>\r\n" +
                "</s:Envelope>";
@@ -99,7 +114,8 @@ public sealed class SonosController : ISonosController
     public async Task SetUriAndPlayAsync(SonosDevice device, string streamUrl, CancellationToken ct, bool useRadioScheme)
     {
         string uriArg = useRadioScheme ? StripScheme(streamUrl) : streamUrl;
-        await CallAsync(device.AvTransportControlUrl, "SetAVTransportURI", BuildSetUriEnvelope(uriArg, useRadioScheme), ct).ConfigureAwait(false);
+        var title = $"RoomRelay — {device.FriendlyName}";
+        await CallAsync(device.AvTransportControlUrl, "SetAVTransportURI", BuildSetUriEnvelope(uriArg, useRadioScheme, title), ct).ConfigureAwait(false);
 
         try
         {

--- a/csharp/src/SonosStreaming.Core/Network/SsdpDiscovery.cs
+++ b/csharp/src/SonosStreaming.Core/Network/SsdpDiscovery.cs
@@ -12,6 +12,7 @@ public sealed class SsdpDiscovery : ISsdpDiscovery
     private static readonly IPAddress SsdpAddrV6 = IPAddress.Parse("ff02::c");
     private const int SsdpPort = 1900;
     private const string SonosSt = "urn:schemas-upnp-org:device:ZonePlayer:1";
+    private const string SonosUdnPrefix = "uuid:RINCON_";
 
     private readonly HttpClient _http;
     private readonly TimeSpan _httpTimeout = TimeSpan.FromSeconds(3);
@@ -111,6 +112,8 @@ public sealed class SsdpDiscovery : ISsdpDiscovery
         var desc = ParseDeviceDescription(resp);
         if (desc == null)
             throw new InvalidOperationException($"Device description from {ip}:{port} did not contain a Sonos friendlyName and UDN.");
+        if (!desc.Value.Udn.StartsWith(SonosUdnPrefix, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Device at {ip}:{port} has UDN \"{desc.Value.Udn}\" which is not a Sonos speaker.");
 
         return new SonosDevice(desc.Value.FriendlyName, ip, port, desc.Value.Udn);
     }
@@ -231,15 +234,10 @@ public sealed class SsdpDiscovery : ISsdpDiscovery
             {
                 var resp = await _http.GetStringAsync(loc, ct).ConfigureAwait(false);
                 var desc = ParseDeviceDescription(resp);
-                if (desc != null)
+                if (desc != null && desc.Value.Udn.StartsWith(SonosUdnPrefix, StringComparison.OrdinalIgnoreCase))
                     devices.Add(new SonosDevice(desc.Value.FriendlyName, ip, port, desc.Value.Udn));
-                else
-                    devices.Add(new SonosDevice($"Sonos @ {ip}", ip, port, $"uuid:unknown-{ip}"));
             }
-            catch
-            {
-                devices.Add(new SonosDevice($"Sonos @ {ip}", ip, port, $"uuid:unknown-{ip}"));
-            }
+            catch { }
         }
 
         return devices;

--- a/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
+++ b/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
@@ -85,9 +85,21 @@ public sealed class PipelineRunner : IDisposable
             if (!ProcessLoopbackSource.IsSupported(out var reason))
                 throw new InvalidOperationException(reason);
 
-            var plb = new ProcessLoopbackSource(selection.ProcessSelection.Pid);
-            plb.Start();
-            _audioSource = plb;
+            Log.Information("Creating process loopback source for pid={Pid} name={Name}",
+                selection.ProcessSelection.Pid, selection.ProcessSelection.Name);
+            try
+            {
+                var plb = new ProcessLoopbackSource(selection.ProcessSelection.Pid);
+                plb.Start();
+                _audioSource = plb;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                throw new InvalidOperationException(
+                    $"Could not capture audio from \"{selection.ProcessSelection.Name}\" (pid={selection.ProcessSelection.Pid}). " +
+                    $"The application may not be playing audio yet, or it may be protected. " +
+                    $"Switch to 'Whole system' capture or try again after the app produces sound.", ex);
+            }
         }
         else
         {
@@ -252,13 +264,13 @@ public sealed class PipelineRunner : IDisposable
                     Log.Information("Pump iter {Iter}: frame {Samples} samples @ {Rate} Hz / {Ch} ch", iter, frame.Samples.Length, frame.SampleRate, frame.Channels);
 
                 var samples = frame.Samples.AsSpan();
+                _spectrumAnalyzer.Process(samples, frame.Channels);
                 _gainStage.Apply(samples, frame.Channels);
                 _balanceStage.Apply(samples, frame.Channels);
                 _equalizer.Process(samples, frame.Channels);
                 _channelDelay.Process(samples, frame.Channels);
                 _volumeStage.Apply(samples);
                 _vuMeter.Process(samples, frame.Channels);
-                _spectrumAnalyzer.Process(samples, frame.Channels);
 
                 var i16Frame = _resampler.Process(frame);
                 _encoder.Encode(i16Frame);

--- a/csharp/tests/SonosStreaming.Tests/MockSonosE2E.cs
+++ b/csharp/tests/SonosStreaming.Tests/MockSonosE2E.cs
@@ -79,6 +79,23 @@ public class MockSonosE2E : IDisposable
     }
 
     [Fact]
+    public void BuildSetUriEnvelope_WithoutTitle_HasEmptyMetadata()
+    {
+        var env = SonosController.BuildSetUriEnvelope("192.168.1.10:8000/stream.aac");
+        env.Should().Contain("<CurrentURIMetaData></CurrentURIMetaData>");
+    }
+
+    [Fact]
+    public void BuildSetUriEnvelope_WithTitle_ContainsDidlLiteMetadata()
+    {
+        var env = SonosController.BuildSetUriEnvelope("192.168.1.10:8000/stream.aac", useRadioScheme: true, metadataTitle: "RoomRelay — Living Room");
+        env.Should().Contain("dc:title");
+        env.Should().Contain("RoomRelay — Living Room");
+        env.Should().Contain("audioBroadcast");
+        env.Should().Contain("DIDL-Lite");
+    }
+
+    [Fact]
     public void SonosController_LpcmSetUri_UsesPlainHttpUri()
     {
         var setUriEnv = SonosController.BuildSetUriEnvelope("http://192.168.1.10:8000/stream/test.wav", useRadioScheme: false);

--- a/csharp/tests/SonosStreaming.Tests/SsdpParserTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/SsdpParserTests.cs
@@ -87,6 +87,35 @@ public class SsdpParserTests
     }
 
     [Fact]
+    public async Task LookupAsync_RejectsNonSonosUdn()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = (ushort)((IPEndPoint)listener.LocalEndpoint).Port;
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            await using var stream = client.GetStream();
+            var buffer = new byte[2048];
+            _ = await stream.ReadAsync(buffer);
+
+            var xml = "<?xml version=\"1.0\"?><root><device><friendlyName>Hue Bridge</friendlyName><UDN>uuid:SomeOtherDevice-1234</UDN></device></root>";
+            var body = Encoding.UTF8.GetBytes(xml);
+            var header = Encoding.ASCII.GetBytes(
+                "HTTP/1.1 200 OK\r\n" +
+                $"Content-Length: {body.Length}\r\n" +
+                "Content-Type: text/xml\r\n\r\n");
+            await stream.WriteAsync(header);
+            await stream.WriteAsync(body);
+        });
+
+        using var discovery = new SsdpDiscovery();
+        var act = () => discovery.LookupAsync(IPAddress.Loopback, port);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not a Sonos speaker*");
+        await serverTask;
+    }
+
+    [Fact]
     public void MergeDevices_DeduplicatesByUdnAndEndpoint()
     {
         var ssdp = new[]
@@ -112,5 +141,24 @@ public class SsdpParserTests
     {
         SsdpDiscovery.FormatHost(IPAddress.Parse("fe80::1")).Should().Be("[fe80::1]");
         SsdpDiscovery.FormatHost(IPAddress.Parse("192.168.1.42")).Should().Be("192.168.1.42");
+    }
+
+    [Fact]
+    public void NonSonosUdn_DoesNotStartWithRinconPrefix()
+    {
+        var xml = "<?xml version=\"1.0\"?><root><device><friendlyName>Hue Bridge</friendlyName><UDN>uuid:SomeOtherDevice-1234</UDN></device></root>";
+        var desc = SsdpDiscovery.ParseDeviceDescription(xml);
+        desc.Should().NotBeNull();
+        desc!.Value.Udn.Should().Be("uuid:SomeOtherDevice-1234");
+        desc.Value.Udn.StartsWith("uuid:RINCON_").Should().BeFalse();
+    }
+
+    [Fact]
+    public void SonosUdn_StartsWithRinconPrefix()
+    {
+        var xml = "<?xml version=\"1.0\"?><root><device><friendlyName>Kitchen</friendlyName><UDN>uuid:RINCON_AABBCCDDEEFF01400</UDN></device></root>";
+        var desc = SsdpDiscovery.ParseDeviceDescription(xml);
+        desc.Should().NotBeNull();
+        desc!.Value.Udn.Should().StartWith("uuid:RINCON_");
     }
 }


### PR DESCRIPTION
## Summary

- **SSDP filtering**: Discovery now rejects non-Sonos devices (e.g. Hue bridges) by requiring uuid:RINCON_ UDN prefix
- **Sticky device fix**: Speaker ListView disabled while streaming; selection reverts on core reject to prevent streaming to a stale device
- **Per-app process list**: Filters out RoomRelay itself, system services, shells/terminals, browsers, and C:\Windows binaries; shows only user-facing apps with visible windows or known media players
- **Friendly COM error messages**: E_NOINTERFACE/InvalidCastException during process loopback now show actionable guidance to switch to Whole system mode
- **Spectrum before DSP**: Visualizer now runs before all DSP stages so it reflects input signal regardless of slider positions
- **Sonos track title**: SetAVTransportURI now sends DIDL-Lite metadata with RoomRelay + room name as dc:title
- **UI polish**: Top MenuBar replaced by subtle overflow button with MenuFlyout

## Test coverage
- 93 tests passing (5 new: SSDP UDN rejection, UDN prefix unit, DIDL-Lite metadata with/without title)
- All existing tests unchanged and passing