### PR TITLE
v1.0.6: improve latency modes and streaming UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ awkward. RoomRelay gives that use case a native, open-source Windows app.
 - Discover Sonos speakers on the local network.
 - Collapse stereo pairs into one selectable room.
 - Built-in volume, per-channel gain, EQ, delay, VU, and spectrum tools.
+- Stable and low-latency streaming modes, with WAV/L16 PCM options for users
+  willing to trade bandwidth and compatibility for lower buffering.
+- Per-application format and latency preferences are remembered when the app
+  session appears again.
 - Tray icon with show/quit actions and close-to-tray behavior.
 - Single-instance behavior: launching RoomRelay again restores the existing
   window instead of opening a duplicate instance.
@@ -60,8 +64,8 @@ awkward. RoomRelay gives that use case a native, open-source Windows app.
 - Like most network Sonos streaming approaches, it is not intended for
   low-latency gaming or video sync.
 - AAC is the recommended default and may have several seconds of Sonos buffering
-  latency. LPCM/WAV is lower latency but experimental, high-bandwidth, and more
-  sensitive to Wi-Fi or older Sonos hardware.
+  latency. WAV/L16 PCM is lower latency but experimental, high-bandwidth, and
+  more sensitive to Wi-Fi or older Sonos hardware.
 - Per-application capture depends on Windows process-loopback support and is
   best on current Windows 11 builds.
 - The first run may require allowing the Windows Defender Firewall prompt on
@@ -118,6 +122,67 @@ Install RoomRelay from the installer, or extract the ZIP and run
 > Prefer an installer? See [`csharp/installer/`](csharp/installer/) for an
 > [Inno Setup](https://jrsoftware.org/isinfo.php) script that builds a
 > standard Windows `.exe` installer with shortcuts and clean uninstall.
+
+## Recommended settings
+
+| Use case | Format | Latency mode | Notes |
+|---|---|---|---|
+| Music, podcasts, radio | AAC 256 kbps | Stable | Recommended default; most tolerant of Wi-Fi and older speakers. |
+| Casual video | WAV PCM or L16 PCM | Low latency | Lower buffering, but high bandwidth and model/network dependent. |
+| Unstable Wi-Fi | AAC 128/192/256 kbps | Stable | Prefer AAC and avoid PCM until the network is reliable. |
+| Older Sonos hardware | AAC 256 kbps | Stable | PCM may fail, stutter, or buffer for a long time. |
+| Per-application capture | Start with AAC 256 kbps | Stable | Switch to Whole system if the app is protected, elevated, browser-isolated, or silent. |
+
+### Latency modes
+
+- **Stable** keeps larger capture and PCM batching buffers. Use it when audio
+  quality and reliability matter more than delay.
+- **Low latency** uses smaller WASAPI and PCM buffers. It can reduce delay for
+  WAV/L16 streams, but it is more sensitive to packet loss, slow writes, and
+  Sonos model behavior.
+- RoomRelay still cannot bypass Sonos' own network buffering. It is not a
+  replacement for HDMI, analog speakers, or gaming/headset audio.
+
+### Format compatibility
+
+- **AAC** is the safest Sonos path and remains the default.
+- **WAV PCM** is lossless 48 kHz stereo in a streaming WAV container. It uses
+  about 1.5 Mbps and may require more Sonos buffering before playback starts.
+- **L16 PCM** is raw network-order PCM advertised as `audio/L16`. It has less
+  container overhead, but compatibility may vary by Sonos model and firmware.
+
+### Troubleshooting discovery
+
+- Allow the Windows Defender Firewall prompt on the private network where Sonos
+  lives.
+- Keep the PC and Sonos on the same subnet/VLAN when possible. SSDP discovery
+  often fails across guest networks, VLAN boundaries, and some mesh isolation
+  modes.
+- Disable VPNs or split-tunnel rules that hijack local multicast traffic.
+- Use **Add by IP** if discovery misses a room. Most Sonos speakers expose the
+  device-description endpoint on port `1400`.
+- Create a diagnostics package when reporting problems. It includes network
+  adapters, selected room, local stream IP, format, latency mode, and timing
+  counters.
+
+### Per-application capture
+
+- Per-app capture uses Windows process loopback and is best on current Windows
+  11 builds.
+- Some browsers, protected media apps, elevated processes, system apps, and
+  short-lived sessions may not be capturable.
+- RoomRelay remembers the last selected app by process name and restores that
+  app's preferred format and latency mode when it appears again.
+
+## Compared with other approaches
+
+| Option | Strength | Tradeoff |
+|---|---|---|
+| RoomRelay | Native Windows live/app audio to Sonos without AirPlay or Bluetooth | Local-network only; Sonos buffering still applies. |
+| AirPlay from Windows apps | Useful when a Windows app exposes AirPlay directly | Model-specific failures are common, and not all Sonos devices support AirPlay. |
+| Bluetooth | Simple on speakers that support it | Not available on many Sonos speakers and does not integrate cleanly with groups. |
+| Sonos line-in | Hardware-supported path on compatible Sonos devices | Requires line-in hardware and still has Sonos buffering delay. |
+| Stream What You Hear | Older Windows workaround | Abandoned/legacy feel and no per-application capture. |
 
 ## What it does
 

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -7,10 +7,10 @@
     <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <Version>1.0.5</Version>
-    <FileVersion>1.0.5.0</FileVersion>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
-    <InformationalVersion>1.0.5</InformationalVersion>
+    <Version>1.0.6</Version>
+    <FileVersion>1.0.6.0</FileVersion>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
+    <InformationalVersion>1.0.6</InformationalVersion>
     <Company>guicn555</Company>
   </PropertyGroup>
 </Project>

--- a/csharp/installer/installer.iss
+++ b/csharp/installer/installer.iss
@@ -3,7 +3,7 @@
 ; Compile with: iscc installer.iss
 
 #define MyAppName "RoomRelay"
-#define MyAppVersion "1.0.5"
+#define MyAppVersion "1.0.6"
 #define MyAppPublisher "guicn555"
 #define MyAppURL "https://github.com/guicn555/RoomRelay"
 #define MyAppExeName "RoomRelay.exe"
@@ -34,7 +34,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\publish\RoomRelay-v1.0.5\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+Source: "..\publish\RoomRelay-v1.0.6\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/csharp/src/SonosStreaming.App/MainWindow.xaml.cs
+++ b/csharp/src/SonosStreaming.App/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using System.Runtime.InteropServices;
 using SonosStreaming.App.ViewModels;
 using SonosStreaming.Core.State;
 using Windows.Win32;
@@ -16,9 +17,15 @@ namespace SonosStreaming.App;
 
 public sealed partial class MainWindow : Window
 {
+    private const int MinWindowWidth = 816;
+    private const int MinWindowHeight = 700;
+    private const uint WM_GETMINMAXINFO = 0x0024;
+    private static readonly UIntPtr MinSizeSubclassId = new(1);
+
     private bool _exiting;
     private Grid? _root;
     private Grid? _titleBar;
+    private SubclassProc? _subclassProc;
 
     public void MarkExiting() => _exiting = true;
 
@@ -33,13 +40,14 @@ public sealed partial class MainWindow : Window
         var appWindow = GetAppWindow();
         if (appWindow != null)
         {
-            appWindow.Resize(new Windows.Graphics.SizeInt32(900, 680));
+            appWindow.Resize(new Windows.Graphics.SizeInt32(855, 720));
             var iconPath = System.IO.Path.Combine(AppContext.BaseDirectory, "Assets", "sonos-streaming.ico");
             if (System.IO.File.Exists(iconPath))
             {
                 try { appWindow.SetIcon(iconPath); } catch { }
             }
         }
+        InstallMinSizeHook();
 
         _root = new Grid { RequestedTheme = ToElementTheme(vm.ThemePreference) };
         _root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(40) });
@@ -242,5 +250,54 @@ public sealed partial class MainWindow : Window
         Hwnd = hwnd;
         var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
         return AppWindow.GetFromWindowId(windowId);
+    }
+
+    private void InstallMinSizeHook()
+    {
+        if (Hwnd == IntPtr.Zero || _subclassProc != null) return;
+        _subclassProc = MinSizeSubclassProc;
+        SetWindowSubclass(Hwnd, _subclassProc, MinSizeSubclassId, UIntPtr.Zero);
+    }
+
+    private IntPtr MinSizeSubclassProc(IntPtr hwnd, uint msg, UIntPtr wParam, IntPtr lParam, UIntPtr idSubclass, UIntPtr refData)
+    {
+        if (msg == WM_GETMINMAXINFO)
+        {
+            var info = Marshal.PtrToStructure<MINMAXINFO>(lParam);
+            info.ptMinTrackSize.X = MinWindowWidth;
+            info.ptMinTrackSize.Y = MinWindowHeight;
+            Marshal.StructureToPtr(info, lParam, false);
+            return IntPtr.Zero;
+        }
+
+        return DefSubclassProc(hwnd, msg, wParam, lParam);
+    }
+
+    [DllImport("comctl32.dll", SetLastError = true)]
+    private static extern bool SetWindowSubclass(IntPtr hWnd, SubclassProc pfnSubclass, UIntPtr uIdSubclass, UIntPtr dwRefData);
+
+    [DllImport("comctl32.dll", SetLastError = true)]
+    private static extern bool RemoveWindowSubclass(IntPtr hWnd, SubclassProc pfnSubclass, UIntPtr uIdSubclass);
+
+    [DllImport("comctl32.dll")]
+    private static extern IntPtr DefSubclassProc(IntPtr hWnd, uint uMsg, UIntPtr wParam, IntPtr lParam);
+
+    private delegate IntPtr SubclassProc(IntPtr hWnd, uint uMsg, UIntPtr wParam, IntPtr lParam, UIntPtr uIdSubclass, UIntPtr dwRefData);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MINMAXINFO
+    {
+        public POINT ptReserved;
+        public POINT ptMaxSize;
+        public POINT ptMaxPosition;
+        public POINT ptMinTrackSize;
+        public POINT ptMaxTrackSize;
     }
 }

--- a/csharp/src/SonosStreaming.App/Services/DiagnosticsPackageService.cs
+++ b/csharp/src/SonosStreaming.App/Services/DiagnosticsPackageService.cs
@@ -27,7 +27,7 @@ public sealed class DiagnosticsPackageService
         }
     }
 
-    public string CreatePackage(AppCore core, PipelineRunner pipeline, string? lastError)
+    public string CreatePackage(AppCore core, PipelineRunner pipeline, AppSettings settings, string? lastError)
     {
         Directory.CreateDirectory(AppDataDir);
         Directory.CreateDirectory(DiagnosticsDir);
@@ -39,7 +39,7 @@ public sealed class DiagnosticsPackageService
         using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
         AddLogs(archive);
         AddFileIfExists(archive, Path.Combine(AppDataDir, "crash.txt"), "crash.txt");
-        AddText(archive, "diagnostics.txt", BuildDiagnostics(core, pipeline, lastError));
+        AddText(archive, "diagnostics.txt", BuildDiagnostics(core, pipeline, settings, lastError));
 
         return zipPath;
     }
@@ -81,7 +81,7 @@ public sealed class DiagnosticsPackageService
         writer.Write(contents);
     }
 
-    private static string BuildDiagnostics(AppCore core, PipelineRunner pipeline, string? lastError)
+    private static string BuildDiagnostics(AppCore core, PipelineRunner pipeline, AppSettings settings, string? lastError)
     {
         var selection = core.Selection;
         var sb = new StringBuilder();
@@ -97,10 +97,35 @@ public sealed class DiagnosticsPackageService
         sb.AppendLine($"Source: {selection.Source}");
         sb.AppendLine($"Process: {selection.ProcessSelection?.Name ?? "n/a"} ({selection.ProcessSelection?.Pid.ToString() ?? "n/a"})");
         sb.AppendLine($"Format: {pipeline.Format}");
+        sb.AppendLine($"Latency mode: {pipeline.LatencyMode}");
+        sb.AppendLine($"Capture buffer target: {pipeline.LatencyMode.CaptureBufferMs()} ms");
+        sb.AppendLine($"PCM flush target: {pipeline.LatencyMode.PcmFlushBytes()} bytes");
         sb.AppendLine($"Selected speaker: {selection.Speaker?.FriendlyName ?? "n/a"}");
+        sb.AppendLine($"Selected speaker IP: {selection.Speaker?.Ip.ToString() ?? "n/a"}:{selection.Speaker?.Port.ToString() ?? "n/a"}");
         sb.AppendLine($"Selected speaker UDN: {selection.Speaker?.Udn ?? "n/a"}");
         sb.AppendLine($"Discovered speakers: {selection.Discovered.Count}");
+        foreach (var d in selection.Discovered)
+            sb.AppendLine($"- {d.FriendlyName} {d.Ip}:{d.Port} {d.Udn}");
+        sb.AppendLine($"Saved manual speaker endpoints: {settings.ManualSpeakerEndpoints.Count}");
+        foreach (var endpoint in settings.ManualSpeakerEndpoints)
+            sb.AppendLine($"- {endpoint.Ip}:{endpoint.Port}");
+        sb.AppendLine($"Last process name: {settings.LastProcessName ?? "n/a"}");
+        sb.AppendLine($"Process preferences: {settings.ProcessPreferences.Count}");
+        foreach (var pref in settings.ProcessPreferences)
+            sb.AppendLine($"- {pref.ProcessName}: {pref.StreamingFormat}, {pref.LatencyMode}");
         sb.AppendLine($"Clients: {pipeline.ClientCount}");
+        sb.AppendLine($"Local stream IP: {pipeline.CurrentLocalIp?.ToString() ?? "n/a"}");
+        sb.AppendLine($"Stream URL: {pipeline.CurrentStreamUrl ?? "n/a"}");
+        sb.AppendLine($"Frames emitted: {pipeline.FramesEmitted}");
+        sb.AppendLine($"Slow stream writes: {pipeline.SlowWriteCount}");
+        sb.AppendLine($"Started UTC: {pipeline.StartedAtUtc?.ToString("O") ?? "n/a"}");
+        sb.AppendLine($"First chunk UTC: {pipeline.FirstChunkAtUtc?.ToString("O") ?? "n/a"}");
+        sb.AppendLine($"First client UTC: {pipeline.FirstClientAtUtc?.ToString("O") ?? "n/a"}");
+        if (pipeline.StartedAtUtc is DateTime started)
+        {
+            sb.AppendLine($"First chunk after ms: {(pipeline.FirstChunkAtUtc - started)?.TotalMilliseconds.ToString("F0") ?? "n/a"}");
+            sb.AppendLine($"First client after ms: {(pipeline.FirstClientAtUtc - started)?.TotalMilliseconds.ToString("F0") ?? "n/a"}");
+        }
         sb.AppendLine($"Last UI error: {lastError ?? "n/a"}");
         sb.AppendLine();
         sb.AppendLine("Network Adapters");

--- a/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
+++ b/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
@@ -104,7 +104,16 @@ public sealed partial class MainViewModel : ObservableObject
     public partial string ErrorMessage { get; set; }
 
     [ObservableProperty]
+    public partial string NotificationTitle { get; set; }
+
+    [ObservableProperty]
+    public partial Microsoft.UI.Xaml.Controls.InfoBarSeverity NotificationSeverity { get; set; }
+
+    [ObservableProperty]
     public partial StreamingFormat SelectedFormat { get; set; }
+
+    [ObservableProperty]
+    public partial StreamingLatencyMode SelectedLatencyMode { get; set; }
 
     [ObservableProperty]
     public partial string EncoderLabel { get; set; }
@@ -144,9 +153,13 @@ public sealed partial class MainViewModel : ObservableObject
         {
             if (IsProcessSourceSelected && SelectedProcess == null)
                 return "Select an application before starting per-application capture.";
+            if (IsProcessSourceSelected)
+                return "If capture fails, the app may be protected, elevated, browser-isolated, or not producing audio yet. Switch to Whole system as fallback.";
             return "";
         }
     }
+
+    public bool IsWholeSystemSourceSelected => !IsProcessSourceSelected;
 
     public string AppVersionLabel => $"RoomRelay {DiagnosticsPackageService.VersionLabel}";
 
@@ -155,16 +168,31 @@ public sealed partial class MainViewModel : ObservableObject
     [ObservableProperty]
     public partial string PlaybackTargetLabel { get; set; }
 
-    private static readonly StreamingFormat[] _visibleFormats = Enum.GetValues<StreamingFormat>()
-        .Where(f => f != StreamingFormat.L16Pcm).ToArray();
+    private static readonly StreamingFormat[] _visibleFormats = Enum.GetValues<StreamingFormat>();
     public StreamingFormat[] AvailableFormats { get; } = _visibleFormats;
     public string[] AvailableFormatNames { get; } = _visibleFormats.Select(f => f.DisplayName()).ToArray();
+    private static readonly StreamingLatencyMode[] _visibleLatencyModes = Enum.GetValues<StreamingLatencyMode>();
+    public string[] AvailableLatencyModeNames { get; } = _visibleLatencyModes.Select(m => m.DisplayName()).ToArray();
 
     public int SelectedFormatIndex
     {
         get => (int)SelectedFormat;
         set { if (value >= 0) SelectedFormat = (StreamingFormat)value; }
     }
+
+    public int SelectedLatencyModeIndex
+    {
+        get => (int)SelectedLatencyMode;
+        set { if (value >= 0) SelectedLatencyMode = (StreamingLatencyMode)value; }
+    }
+
+    public string LatencyModeHelp => SelectedLatencyMode == StreamingLatencyMode.LowLatency
+        ? "Low latency uses smaller buffers for PCM/WAV and may be more sensitive to Wi-Fi or older Sonos hardware."
+        : SelectedFormat.IsPcm()
+            ? "Stable keeps larger buffers and is recommended for music, podcasts, radio, and unreliable Wi-Fi."
+            : "AAC always uses Stable mode because Sonos and AAC buffering dominate latency. Use WAV/L16 PCM for low-latency mode.";
+    public string LatencyModeLabel => SelectedLatencyMode.DisplayName();
+    public bool CanSelectLatencyMode => SelectedFormat.IsPcm() && IsNotStreaming;
 
     public bool IsNotStreaming => StateLabel != "Streaming";
 
@@ -200,7 +228,10 @@ public sealed partial class MainViewModel : ObservableObject
         DelayMsL = settings.DelayMsL;
         DelayMsR = settings.DelayMsR;
         ErrorMessage = "";
+        NotificationTitle = "";
+        NotificationSeverity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error;
         SelectedFormat = settings.StreamingFormat;
+        SelectedLatencyMode = settings.LatencyMode;
         EncoderLabel = settings.StreamingFormat.DisplayName();
         ManualSpeakerIp = "";
         ManualSpeakerPort = "1400";
@@ -212,6 +243,7 @@ public sealed partial class MainViewModel : ObservableObject
         PlaybackTargetLabel = "No room selected";
         ThemePreference = settings.ThemePreference;
         Pipeline.Format = settings.StreamingFormat;
+        Pipeline.LatencyMode = settings.LatencyMode;
         SyncSavedManualEndpoints();
 
         // Apply persisted settings to pipeline stages so restart restores the
@@ -238,7 +270,7 @@ public sealed partial class MainViewModel : ObservableObject
         try { await Pipeline.StopAsync(speaker); } catch { }
         try { _core.BeginStop(); _core.FinishStop(); } catch { }
         ErrorMessage = "Audio format changed. Please restart the stream.";
-        IsErrorVisible = true;
+        ShowNotification("Stream Error", ErrorMessage, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error);
         StateLabel = "Idle";
     }
 
@@ -321,11 +353,29 @@ public sealed partial class MainViewModel : ObservableObject
 
     partial void OnSelectedFormatChanged(StreamingFormat value)
     {
+        if (!value.IsPcm() && SelectedLatencyMode != StreamingLatencyMode.Stable)
+            SelectedLatencyMode = StreamingLatencyMode.Stable;
+
         Pipeline.Format = value;
         Settings.StreamingFormat = value;
+        RememberSelectedProcessPreference();
         Settings.Save();
         EncoderLabel = value.DisplayName();
         OnPropertyChanged(nameof(SelectedFormatIndex));
+        OnPropertyChanged(nameof(CanSelectLatencyMode));
+        OnPropertyChanged(nameof(LatencyModeHelp));
+    }
+
+    partial void OnSelectedLatencyModeChanged(StreamingLatencyMode value)
+    {
+        Pipeline.LatencyMode = value;
+        Settings.LatencyMode = value;
+        RememberSelectedProcessPreference();
+        Settings.Save();
+        OnPropertyChanged(nameof(SelectedLatencyModeIndex));
+        OnPropertyChanged(nameof(LatencyModeHelp));
+        OnPropertyChanged(nameof(LatencyModeLabel));
+        OnPropertyChanged(nameof(CanSelectLatencyMode));
     }
 
     partial void OnThemePreferenceChanged(ThemePreference value)
@@ -402,6 +452,9 @@ public sealed partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(SourceStatusLabel));
         if (value != null)
         {
+            Settings.LastProcessName = value.Name;
+            ApplyProcessPreference(value.Name);
+            Settings.Save();
             try { _core.SetSource(AudioSourceSelection.Process, new AudioSourceProcessSelection { Pid = value.Pid, Name = value.DisplayName }); }
             catch (Exception ex) { Log.Warning(ex, "Cannot select process"); }
         }
@@ -414,7 +467,7 @@ public sealed partial class MainViewModel : ObservableObject
         try { await Pipeline.StopAsync(speaker); } catch { }
         try { _core.BeginStop(); _core.FinishStop(); } catch { }
         ErrorMessage = ex.Message;
-        IsErrorVisible = true;
+        ShowNotification("Stream Error", ErrorMessage, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error);
         StateLabel = "Idle";
     }
 
@@ -422,6 +475,7 @@ public sealed partial class MainViewModel : ObservableObject
     {
         StartCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(SourceStatusLabel));
+        OnPropertyChanged(nameof(IsWholeSystemSourceSelected));
     }
 
     // Starts a background task that refreshes the AudioProcesses collection
@@ -469,6 +523,39 @@ public sealed partial class MainViewModel : ObservableObject
             if (!existing.Contains(p.Pid))
                 AudioProcesses.Add(p);
         }
+
+        if (IsProcessSourceSelected && SelectedProcess == null && !string.IsNullOrWhiteSpace(Settings.LastProcessName))
+        {
+            var previous = AudioProcesses.FirstOrDefault(p => string.Equals(p.Name, Settings.LastProcessName, StringComparison.OrdinalIgnoreCase));
+            if (previous != null)
+                SelectedProcess = previous;
+        }
+    }
+
+    private void ApplyProcessPreference(string processName)
+    {
+        var pref = Settings.ProcessPreferences.FirstOrDefault(p => string.Equals(p.ProcessName, processName, StringComparison.OrdinalIgnoreCase));
+        if (pref == null) return;
+
+        SelectedFormat = pref.StreamingFormat;
+        SelectedLatencyMode = pref.LatencyMode;
+    }
+
+    private void RememberSelectedProcessPreference()
+    {
+        var processName = SelectedProcess?.Name;
+        if (!IsProcessSourceSelected) return;
+        if (string.IsNullOrWhiteSpace(processName)) return;
+
+        var pref = Settings.ProcessPreferences.FirstOrDefault(p => string.Equals(p.ProcessName, processName, StringComparison.OrdinalIgnoreCase));
+        if (pref == null)
+        {
+            pref = new AppProcessPreference { ProcessName = processName };
+            Settings.ProcessPreferences.Add(pref);
+        }
+
+        pref.StreamingFormat = SelectedFormat;
+        pref.LatencyMode = SelectedLatencyMode;
     }
 
     [RelayCommand]
@@ -569,7 +656,9 @@ public sealed partial class MainViewModel : ObservableObject
         catch (Exception ex)
         {
             Log.Warning(ex, "Manual speaker lookup failed for {Ip}:{Port}", ip, port);
-            ManualSpeakerStatus = $"Could not reach {ip}:{port}";
+            ManualSpeakerStatus = ex is InvalidOperationException && !string.IsNullOrWhiteSpace(ex.Message)
+                ? ex.Message
+                : $"Could not reach {ip}:{port}. Check the IP address, port 1400, firewall, VLAN, and that the device is a Sonos speaker.";
         }
     }
 
@@ -639,6 +728,7 @@ public sealed partial class MainViewModel : ObservableObject
         AddManualSpeakerCommand.NotifyCanExecuteChanged();
         RemoveManualSpeakerCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(IsNotStreaming));
+        OnPropertyChanged(nameof(CanSelectLatencyMode));
         OnPropertyChanged(nameof(CanAddManualSpeaker));
         OnPropertyChanged(nameof(CanRemoveManualSpeaker));
         OnPropertyChanged(nameof(ClientStatusLabel));
@@ -818,7 +908,7 @@ public sealed partial class MainViewModel : ObservableObject
         if (IsProcessSourceSelected && SelectedProcess == null)
         {
             ErrorMessage = "Select an application before starting per-application capture.";
-            IsErrorVisible = true;
+            ShowNotification("Source Required", ErrorMessage, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Warning);
             StartCommand.NotifyCanExecuteChanged();
             return;
         }
@@ -842,16 +932,21 @@ public sealed partial class MainViewModel : ObservableObject
             StateLabel = "Streaming";
             PlaybackTargetLabel = speaker.FriendlyName;
 
-            if (Pipeline.CurrentMixFormat is MixFormat fmt)
-                InputFormatLabel = $"{fmt.SampleRate} Hz · {fmt.Channels} ch · {fmt.BitsPerSample}-bit {(fmt.IsFloat ? "float" : "int")}";
+            UpdateInputFormatLabel();
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Start failed");
             try { await Pipeline.StopAsync(speaker); } catch { }
             try { _core.BeginStop(); _core.FinishStop(); } catch { }
-            ErrorMessage = ex.Message;
-            IsErrorVisible = true;
+
+            if (IsProcessSourceSelected && IsPerApplicationCaptureFailure(ex))
+            {
+                if (await TryStartWholeSystemFallbackAsync(speaker, ex))
+                    return;
+            }
+
+            ShowNotification("Stream Error", ex.Message, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error);
             StateLabel = "Idle";
             OnPropertyChanged(nameof(SelectedSpeakerLabel));
         }
@@ -864,8 +959,7 @@ public sealed partial class MainViewModel : ObservableObject
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to open logs folder");
-            ErrorMessage = $"Could not open logs folder: {ex.Message}";
-            IsErrorVisible = true;
+            ShowNotification("Logs Error", $"Could not open logs folder: {ex.Message}", Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error);
         }
     }
 
@@ -874,7 +968,7 @@ public sealed partial class MainViewModel : ObservableObject
     {
         try
         {
-            var package = _diagnostics.CreatePackage(_core, Pipeline, string.IsNullOrWhiteSpace(ErrorMessage) ? null : ErrorMessage);
+            var package = _diagnostics.CreatePackage(_core, Pipeline, Settings, string.IsNullOrWhiteSpace(ErrorMessage) ? null : ErrorMessage);
             DiagnosticsStatus = $"Diagnostics package created: {package}";
             Log.Information("Diagnostics package created at {Path}", package);
             _diagnostics.OpenDiagnosticsPackage(package);
@@ -882,8 +976,7 @@ public sealed partial class MainViewModel : ObservableObject
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to create diagnostics package");
-            ErrorMessage = $"Could not create diagnostics package: {ex.Message}";
-            IsErrorVisible = true;
+            ShowNotification("Diagnostics Error", $"Could not create diagnostics package: {ex.Message}", Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error);
         }
 
         return Task.CompletedTask;
@@ -910,5 +1003,77 @@ public sealed partial class MainViewModel : ObservableObject
             try { _core.FinishStop(); } catch { }
             StateLabel = "Idle";
         }
+    }
+
+    private async Task<bool> TryStartWholeSystemFallbackAsync(SonosDevice speaker, Exception originalError)
+    {
+        var failedSource = SelectedProcess?.DisplayName ?? SelectedProcess?.Name ?? "the selected application";
+        Log.Warning(originalError, "Per-application capture failed for {Source}; retrying with whole-system capture", failedSource);
+
+        try
+        {
+            IsProcessSourceSelected = false;
+            _core.SetSource(AudioSourceSelection.WholeSystem);
+            _core.BeginStart();
+            StateLabel = "Starting…";
+
+            await Pipeline.StartAsync(speaker, CancellationToken.None);
+            _core.FinishStart();
+            StateLabel = "Streaming";
+            PlaybackTargetLabel = speaker.FriendlyName;
+            UpdateInputFormatLabel();
+
+            ShowNotification(
+                "Using Whole System",
+                $"{failedSource} cannot be captured per application on this Windows build. RoomRelay switched to whole system audio.",
+                Microsoft.UI.Xaml.Controls.InfoBarSeverity.Warning);
+            return true;
+        }
+        catch (Exception fallbackEx)
+        {
+            Log.Error(fallbackEx, "Whole-system fallback failed");
+            try { await Pipeline.StopAsync(speaker); } catch { }
+            try { _core.BeginStop(); _core.FinishStop(); } catch { }
+
+            ShowNotification(
+                "Stream Error",
+                $"Per-application capture failed, and whole-system fallback also failed: {fallbackEx.Message}",
+                Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error);
+            StateLabel = "Idle";
+            OnPropertyChanged(nameof(SelectedSpeakerLabel));
+            return true;
+        }
+    }
+
+    private static bool IsPerApplicationCaptureFailure(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException!)
+        {
+            if (current is InvalidCastException)
+                return true;
+
+            var message = current.Message;
+            if (message.Contains("Could not capture audio from", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("cannot be captured per-application", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("E_NOINTERFACE", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("No such interface supported", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private void UpdateInputFormatLabel()
+    {
+        if (Pipeline.CurrentMixFormat is MixFormat fmt)
+            InputFormatLabel = $"{fmt.SampleRate} Hz · {fmt.Channels} ch · {fmt.BitsPerSample}-bit {(fmt.IsFloat ? "float" : "int")}";
+    }
+
+    private void ShowNotification(string title, string message, Microsoft.UI.Xaml.Controls.InfoBarSeverity severity)
+    {
+        NotificationTitle = title;
+        ErrorMessage = message;
+        NotificationSeverity = severity;
+        IsErrorVisible = true;
     }
 }

--- a/csharp/src/SonosStreaming.App/Views/MainPage.xaml
+++ b/csharp/src/SonosStreaming.App/Views/MainPage.xaml
@@ -29,7 +29,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Padding="12">
+    <Grid Padding="12" MinWidth="816" MinHeight="620">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="380" />
             <ColumnDefinition Width="12" />
@@ -37,7 +37,7 @@
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="0" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="6" />
             <RowDefinition Height="Auto" />
@@ -96,6 +96,17 @@
             </Grid>
         </Border>
 
+        <InfoBar
+            Grid.Row="1"
+            Grid.ColumnSpan="3"
+            Margin="0,12,0,0"
+            Title="{x:Bind ViewModel.NotificationTitle, Mode=OneWay}"
+            Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}"
+            IsOpen="{x:Bind ViewModel.IsErrorVisible, Mode=OneWay}"
+            Severity="{x:Bind ViewModel.NotificationSeverity, Mode=OneWay}"
+            IsClosable="True"
+            CloseButtonClick="ErrorInfoBar_CloseButtonClick" />
+
         <!-- Left panel -->
         <ScrollViewer Grid.Row="2" Grid.Column="0" VerticalScrollMode="Auto">
             <StackPanel Spacing="16">
@@ -115,6 +126,10 @@
                             BorderThickness="0" />
                         <TextBlock
                             Text="Grouped rooms and stereo pairs are shown as one Sonos playback target."
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Text="If no rooms appear, allow RoomRelay through Windows Firewall, disable VPN split tunneling, check that PC and Sonos are on the same subnet/VLAN, or add the room by IP."
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             TextWrapping="Wrap" />
                         <TextBlock
@@ -138,24 +153,12 @@
                     </StackPanel>
                 </Border>
 
-                <InfoBar
-                    Title="Stream Error"
-                    Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}"
-                    IsOpen="{x:Bind ViewModel.IsErrorVisible, Mode=OneWay}"
-                    Severity="Error"
-                    IsClosable="True"
-                    CloseButtonClick="ErrorInfoBar_CloseButtonClick" />
-                <TextBlock
-                    Text="{x:Bind ViewModel.DiagnosticsStatus, Mode=OneWay}"
-                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    TextWrapping="Wrap" />
-
                 <!-- Manual speaker -->
                 <Border Style="{StaticResource CardBorderStyle}">
                     <StackPanel Spacing="8">
                         <TextBlock Text="Add by IP" Style="{StaticResource SectionHeaderStyle}" />
                         <TextBlock
-                            Text="Use this if SSDP discovery misses a room. Manual entries are saved and included in future scans."
+                            Text="Use this if SSDP discovery misses a room. Manual entries are saved and included in future scans. Most Sonos speakers use port 1400."
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             TextWrapping="Wrap" />
                         <Grid ColumnSpacing="8" Margin="0,4,0,0">
@@ -215,8 +218,8 @@
                 <Border Style="{StaticResource CardBorderStyle}">
                     <StackPanel Spacing="8">
                         <TextBlock Text="Source" Style="{StaticResource SectionHeaderStyle}" />
-                        <RadioButton x:Name="WholeSystemRadio" Content="Whole system" GroupName="Source" IsChecked="True" Checked="WholeSystemRadio_Checked" />
-                        <RadioButton x:Name="ProcessRadio" Content="Per application" GroupName="Source" Checked="ProcessRadio_Checked" />
+                        <RadioButton x:Name="WholeSystemRadio" Content="Whole system" GroupName="Source" IsChecked="{x:Bind ViewModel.IsWholeSystemSourceSelected, Mode=OneWay}" Checked="WholeSystemRadio_Checked" />
+                        <RadioButton x:Name="ProcessRadio" Content="Per application" GroupName="Source" IsChecked="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay}" Checked="ProcessRadio_Checked" />
                         <TextBlock Text="Per-application capture uses Windows process loopback and works best on current Windows 11 builds. Use Whole system if an app does not appear or cannot start." TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         <ComboBox
                             ItemsSource="{x:Bind ViewModel.AudioProcesses, Mode=OneWay}"
@@ -235,6 +238,13 @@
                             SelectedIndex="{x:Bind ViewModel.SelectedFormatIndex, Mode=TwoWay}"
                             IsEnabled="{x:Bind ViewModel.IsNotStreaming, Mode=OneWay}"
                             HorizontalAlignment="Stretch" />
+                        <TextBlock Text="Latency mode" Margin="0,8,0,0" />
+                        <ComboBox
+                            ItemsSource="{x:Bind ViewModel.AvailableLatencyModeNames}"
+                            SelectedIndex="{x:Bind ViewModel.SelectedLatencyModeIndex, Mode=TwoWay}"
+                            IsEnabled="{x:Bind ViewModel.CanSelectLatencyMode, Mode=OneWay}"
+                            HorizontalAlignment="Stretch" />
+                        <TextBlock Text="{x:Bind ViewModel.LatencyModeHelp, Mode=OneWay}" TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
                 </Border>
 
@@ -371,18 +381,38 @@
                 BorderThickness="1"
                 CornerRadius="8"
                 Padding="12,8">
-            <StackPanel Orientation="Horizontal" Spacing="16" VerticalAlignment="Center">
-                <Ellipse Width="10" Height="10" Fill="{x:Bind ViewModel.StatusBrush, Mode=OneWay}" />
-                <TextBlock Text="{x:Bind ViewModel.StateLabel, Mode=OneWay}" VerticalAlignment="Center" />
-                <Rectangle Width="1" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
-                <TextBlock Text="{x:Bind ViewModel.PlaybackTargetLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                <Rectangle Width="1" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
-                <TextBlock Text="{x:Bind ViewModel.InputFormatLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                <Rectangle Width="1" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
-                <TextBlock Text="{x:Bind ViewModel.EncoderLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                <Rectangle Width="1" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
-                <TextBlock Text="{x:Bind ViewModel.ClientStatusLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-            </StackPanel>
+            <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid Grid.Column="0" ColumnSpacing="12" MinWidth="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="1.2*" MinWidth="120" />
+                        <ColumnDefinition Width="1.4*" MinWidth="140" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="1.2*" MinWidth="150" />
+                    </Grid.ColumnDefinitions>
+                    <Ellipse Grid.Column="0" Width="10" Height="10" Fill="{x:Bind ViewModel.StatusBrush, Mode=OneWay}" />
+                    <TextBlock Grid.Column="1" Text="{x:Bind ViewModel.StateLabel, Mode=OneWay}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Grid.Column="2" Text="{x:Bind ViewModel.PlaybackTargetLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" ToolTipService.ToolTip="{x:Bind ViewModel.PlaybackTargetLabel, Mode=OneWay}" />
+                    <TextBlock Grid.Column="3" Text="{x:Bind ViewModel.InputFormatLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" ToolTipService.ToolTip="{x:Bind ViewModel.InputFormatLabel, Mode=OneWay}" />
+                    <TextBlock Grid.Column="4" Text="{x:Bind ViewModel.EncoderLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Grid.Column="5" Text="{x:Bind ViewModel.LatencyModeLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Grid.Column="6" Text="{x:Bind ViewModel.ClientStatusLabel, Mode=OneWay}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" ToolTipService.ToolTip="{x:Bind ViewModel.ClientStatusLabel, Mode=OneWay}" />
+                </Grid>
+                <TextBlock
+                    Grid.Column="1"
+                    Text="{x:Bind ViewModel.DiagnosticsStatus, Mode=OneWay}"
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    TextTrimming="CharacterEllipsis"
+                    MaxWidth="420"
+                    ToolTipService.ToolTip="{x:Bind ViewModel.DiagnosticsStatus, Mode=OneWay}" />
+            </Grid>
         </Border>
     </Grid>
 </Page>

--- a/csharp/src/SonosStreaming.Core/Audio/L16PcmEncoder.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/L16PcmEncoder.cs
@@ -6,8 +6,14 @@ namespace SonosStreaming.Core.Audio;
 public sealed class L16PcmEncoder : IAudioEncoder
 {
     private byte[] _batchBuffer = new byte[32768];
+    private readonly int _minFlushBytes;
     private int _batchOffset;
     private bool _disposed;
+
+    public L16PcmEncoder(int minFlushBytes = 8192)
+    {
+        _minFlushBytes = minFlushBytes;
+    }
 
     public void Encode(PcmFrameI16 pcmFrame)
     {
@@ -24,13 +30,9 @@ public sealed class L16PcmEncoder : IAudioEncoder
         }
     }
 
-    // ~43 ms of 48 kHz stereo 16-bit PCM. Keep this lower than WAV's previous
-    // 85 ms cadence to reduce latency for video use.
-    private const int MinFlushBytes = 8192;
-
     public ReadOnlyMemory<byte> FlushChunk()
     {
-        if (_batchOffset < MinFlushBytes) return ReadOnlyMemory<byte>.Empty;
+        if (_batchOffset < _minFlushBytes) return ReadOnlyMemory<byte>.Empty;
         return DoFlush();
     }
 

--- a/csharp/src/SonosStreaming.Core/Audio/LpcmEncoder.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/LpcmEncoder.cs
@@ -6,11 +6,13 @@ namespace SonosStreaming.Core.Audio;
 public sealed class LpcmEncoder : IAudioEncoder
 {
     private byte[] _batchBuffer = new byte[65536];
+    private readonly int _minFlushBytes;
     private int _batchOffset;
     private bool _disposed;
 
-    public LpcmEncoder()
+    public LpcmEncoder(int minFlushBytes = 8192)
     {
+        _minFlushBytes = minFlushBytes;
     }
 
     public void Encode(PcmFrameI16 pcmFrame)
@@ -23,13 +25,9 @@ public sealed class LpcmEncoder : IAudioEncoder
         _batchOffset += byteCount;
     }
 
-    // ~43 ms of 48 kHz stereo 16-bit PCM. Lower cadence is more useful for
-    // video while still avoiding tiny TCP writes.
-    private const int MinFlushBytes = 8192;
-
     public ReadOnlyMemory<byte> FlushChunk()
     {
-        if (_batchOffset < MinFlushBytes) return ReadOnlyMemory<byte>.Empty;
+        if (_batchOffset < _minFlushBytes) return ReadOnlyMemory<byte>.Empty;
         return DoFlush();
     }
 

--- a/csharp/src/SonosStreaming.Core/Audio/ProcessLoopbackSource.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/ProcessLoopbackSource.cs
@@ -32,12 +32,14 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
 
     private readonly uint _pid;
     private readonly ProcessLoopbackMode _mode;
+    private readonly int _captureBufferMs;
     private readonly MixFormat _format = new(48000, 2, 32, true);
 
-    public ProcessLoopbackSource(int pid, ProcessLoopbackMode mode = ProcessLoopbackMode.IncludeProcessTree)
+    public ProcessLoopbackSource(int pid, ProcessLoopbackMode mode = ProcessLoopbackMode.IncludeProcessTree, int captureBufferMs = 200)
     {
         _pid = (uint)pid;
         _mode = mode;
+        _captureBufferMs = captureBufferMs;
     }
 
     public new MixFormat MixFormat => _format;
@@ -76,7 +78,7 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
             cbSize = 0,
         };
 
-        const long hnsBufferDuration = 2_000_000L;
+        long hnsBufferDuration = _captureBufferMs * 10_000L;
         try
         {
             client.Initialize(
@@ -96,7 +98,7 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
         }
 
         BeginCapture(client, &wfx, $"ProcessLoopback-{_pid}");
-        Log.Information("Process loopback capture started for pid={Pid} mode={Mode}", _pid, _mode);
+        Log.Information("Process loopback capture started for pid={Pid} mode={Mode} buffer={BufferMs} ms", _pid, _mode, _captureBufferMs);
     }
 
     private WinAudioClient ActivateSync()
@@ -292,9 +294,11 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                                             catch { }
 
                                             var (processName, friendlyName) = GetProcessLabels(pid);
-                                            if (!IsUserFacingProcess(pid, processName))
+                                            if (!IsUserFacingProcess(pid, processName, sessionName, friendlyName))
                                             {
                                                 systemPidSkipped++;
+                                                Log.Verbose("Skipping audio session pid={Pid} process={Process} session={Session} friendly={Friendly}",
+                                                    pid, processName ?? "n/a", sessionName ?? "n/a", friendlyName ?? "n/a");
                                                 continue;
                                             }
                                             string displayName = !string.IsNullOrEmpty(sessionName)
@@ -346,9 +350,26 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
         "msedge", "chrome", "firefox", "opera", "brave", "vivaldi"
     };
 
-    private static bool IsUserFacingProcess(int pid, string? processName)
+    private static readonly string[] KnownMediaPlayers = new[]
+    {
+        "spotify", "foobar2000", "musicbee", "aimp", "vlc", "winamp", "mediamonkey", "groove",
+        "wmplayer", "mediaplayer", "microsoft.media.player", "zunemusic",
+        "applemusic", "itunes", "tidal", "qobuz", "deezer", "amazonmusic", "amazon music",
+        "plexamp", "roon", "audirvana", "jriver", "musicbee", "potplayer", "mpc-hc", "mpc-be",
+        "youtube music", "ytmusic", "youtubemusic"
+    };
+
+    private static readonly string[] KnownMediaLabels = new[]
+    {
+        "media player", "windows media player", "spotify", "foobar2000", "musicbee", "aimp", "vlc", "winamp", "mediamonkey",
+        "apple music", "itunes", "tidal", "qobuz", "deezer", "amazon music", "plexamp", "roon", "audirvana",
+        "youtube music", "yt music", "jriver", "potplayer", "media player classic", "mpc-hc", "mpc-be"
+    };
+
+    private static bool IsUserFacingProcess(int pid, string? processName, string? sessionName, string? friendlyName)
     {
         if (string.IsNullOrEmpty(processName)) return false;
+        if (IsKnownMediaProcess(processName) || IsKnownMediaLabel(sessionName) || IsKnownMediaLabel(friendlyName)) return true;
         if (SystemProcessNames.Contains(processName, StringComparer.OrdinalIgnoreCase)) return false;
 
         try
@@ -374,9 +395,6 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
             // Some legitimate media apps hide their main window when minimized to tray.
             if (!string.IsNullOrWhiteSpace(proc.MainWindowTitle)) return true;
 
-            var knownMediaPlayers = new[] { "spotify", "foobar2000", "musicbee", "aimp", "vlc", "winamp", "mediamonkey", "groove" };
-            if (knownMediaPlayers.Contains(processName, StringComparer.OrdinalIgnoreCase)) return true;
-
             return false;
         }
         catch
@@ -384,6 +402,13 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
             return false;
         }
     }
+
+    private static bool IsKnownMediaProcess(string processName) =>
+        KnownMediaPlayers.Contains(processName, StringComparer.OrdinalIgnoreCase);
+
+    private static bool IsKnownMediaLabel(string? label) =>
+        !string.IsNullOrWhiteSpace(label) &&
+        KnownMediaLabels.Any(known => label.Contains(known, StringComparison.OrdinalIgnoreCase));
 
     private static (string? processName, string? friendlyName) GetProcessLabels(int pid)
     {

--- a/csharp/src/SonosStreaming.Core/Audio/WasapiLoopbackSource.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/WasapiLoopbackSource.cs
@@ -18,8 +18,12 @@ public sealed unsafe class WasapiLoopbackSource : WasapiCaptureBase
 
     private Thread? _silenceThread;
     private long _lastDataTicks;
+    private readonly int _captureBufferMs;
 
-    public WasapiLoopbackSource() { }
+    public WasapiLoopbackSource(int captureBufferMs = 200)
+    {
+        _captureBufferMs = captureBufferMs;
+    }
 
     // Allow querying the mix format before Start() is called.
     public new MixFormat MixFormat => _mixFormat ?? ProbeMixFormat();
@@ -43,7 +47,7 @@ public sealed unsafe class WasapiLoopbackSource : WasapiCaptureBase
         client.GetMixFormat(&pwfx);
         try
         {
-            const long hnsBufferDuration = 2_000_000L; // 200 ms
+            long hnsBufferDuration = _captureBufferMs * 10_000L;
             client.Initialize(
                 AUDCLNT_SHAREMODE.AUDCLNT_SHAREMODE_SHARED,
                 AUDCLNT_STREAMFLAGS_LOOPBACK | AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
@@ -55,8 +59,8 @@ public sealed unsafe class WasapiLoopbackSource : WasapiCaptureBase
             _lastDataTicks = DateTime.UtcNow.Ticks;
             BeginCapture(client, pwfx, "WasapiLoopback");
 
-            Log.Information("WASAPI loopback capture started: {Rate} Hz, {Ch} ch, {Bits}-bit, float={IsFloat}",
-                _mixFormat!.SampleRate, _mixFormat!.Channels, _mixFormat!.BitsPerSample, _mixFormat!.IsFloat);
+            Log.Information("WASAPI loopback capture started: {Rate} Hz, {Ch} ch, {Bits}-bit, float={IsFloat}, buffer={BufferMs} ms",
+                _mixFormat!.SampleRate, _mixFormat!.Channels, _mixFormat!.BitsPerSample, _mixFormat!.IsFloat, _captureBufferMs);
         }
         finally
         {

--- a/csharp/src/SonosStreaming.Core/Network/SonosController.cs
+++ b/csharp/src/SonosStreaming.Core/Network/SonosController.cs
@@ -124,9 +124,12 @@ public sealed class SonosController : ISonosController
         => await SetUriAndPlayAsync(device, streamUrl, ct, useRadioScheme, "audio/aac").ConfigureAwait(false);
 
     public async Task SetUriAndPlayAsync(SonosDevice device, string streamUrl, CancellationToken ct, bool useRadioScheme, string contentType)
+        => await SetUriAndPlayAsync(device, streamUrl, ct, useRadioScheme, contentType, metadataTitle: null).ConfigureAwait(false);
+
+    public async Task SetUriAndPlayAsync(SonosDevice device, string streamUrl, CancellationToken ct, bool useRadioScheme, string contentType, string? metadataTitle)
     {
         string uriArg = useRadioScheme ? StripScheme(streamUrl) : streamUrl;
-        var title = $"RoomRelay — {device.FriendlyName}";
+        var title = string.IsNullOrWhiteSpace(metadataTitle) ? $"RoomRelay - {device.FriendlyName}" : metadataTitle;
         await CallAsync(device.AvTransportControlUrl, "SetAVTransportURI", BuildSetUriEnvelope(uriArg, useRadioScheme, title, streamUrl, contentType), ct).ConfigureAwait(false);
 
         try

--- a/csharp/src/SonosStreaming.Core/Network/StreamServer.cs
+++ b/csharp/src/SonosStreaming.Core/Network/StreamServer.cs
@@ -19,12 +19,14 @@ public sealed class StreamServer : IStreamServer
     private readonly List<Task> _connectionTasks = new();
     private readonly object _lock = new();
     private IPEndPoint _localEndPoint;
+    private int _slowWriteCount;
 
     // 44-byte RIFF/WAVE header for 48 kHz stereo 16-bit PCM streaming.
     private static readonly byte[] LpcmWavHeader = GenerateWavHeader();
 
     public IPEndPoint LocalEndPoint => _localEndPoint;
     public string StreamPath => $"/stream/{_streamToken}{_format.FileExtension()}";
+    public int SlowWriteCount => Volatile.Read(ref _slowWriteCount);
 
     public StreamServer(BroadcastChannel<ReadOnlyMemory<byte>> broadcast, int port = 8000, StreamingFormat format = StreamingFormat.Aac256, IPAddress? bindAddress = null)
     {
@@ -181,6 +183,7 @@ public sealed class StreamServer : IStreamServer
                     if (writeMs > 250)
                     {
                         slowWrites++;
+                        Interlocked.Increment(ref _slowWriteCount);
                         Log.Warning("Slow stream write to {Peer}: {Bytes} bytes in {Ms:F0} ms (format={Format})",
                             peer, frame.Length, writeMs, _format);
                     }

--- a/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
+++ b/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
@@ -3,6 +3,7 @@ using SonosStreaming.Core.Audio.Dsp;
 using SonosStreaming.Core.Network;
 using SonosStreaming.Core.State;
 using Serilog;
+using System.Net;
 
 namespace SonosStreaming.Core.Pipeline;
 
@@ -20,6 +21,7 @@ public sealed class PipelineRunner : IDisposable
     private readonly BroadcastChannel<ReadOnlyMemory<byte>> _broadcast;
 
     public StreamingFormat Format { get; set; } = StreamingFormat.Aac256;
+    public StreamingLatencyMode LatencyMode { get; set; } = StreamingLatencyMode.Stable;
 
     private StreamServer? _streamServer;
     private IAudioSource? _audioSource;
@@ -31,6 +33,7 @@ public sealed class PipelineRunner : IDisposable
     private Task? _pumpTask;
     private Task? _clientCountTask;
     private long _framesEmitted;
+    private int _lastSlowWriteCount;
     private DateTime _pipelineStart;
     private DateTime _lastFrameLog;
     private int _clippingHold;
@@ -45,6 +48,13 @@ public sealed class PipelineRunner : IDisposable
     public BroadcastChannel<ReadOnlyMemory<byte>> Broadcast => _broadcast;
     public MixFormat? CurrentMixFormat { get; private set; }
     public bool IsClipping { get; private set; }
+    public IPAddress? CurrentLocalIp { get; private set; }
+    public string? CurrentStreamUrl { get; private set; }
+    public DateTime? StartedAtUtc { get; private set; }
+    public DateTime? FirstChunkAtUtc { get; private set; }
+    public DateTime? FirstClientAtUtc { get; private set; }
+    public long FramesEmitted => Interlocked.Read(ref _framesEmitted);
+    public int SlowWriteCount => _streamServer?.SlowWriteCount ?? _lastSlowWriteCount;
 
     /// <summary>
     /// Raised when the pump loop terminates with an unhandled exception.
@@ -80,8 +90,11 @@ public sealed class PipelineRunner : IDisposable
             throw new InvalidOperationException("Select an application before starting per-application capture.");
 
         var localIp = LocalIpResolver.PickLocalIpFor(device.Ip);
+        CurrentLocalIp = localIp;
         _streamServer = new StreamServer(_broadcast, _options.HttpPort, Format, localIp);
         _streamServer.Start();
+        Log.Information("Pipeline latency mode: {LatencyMode}, captureBuffer={CaptureBufferMs} ms, pcmFlushBytes={PcmFlushBytes}",
+            LatencyMode, LatencyMode.CaptureBufferMs(), LatencyMode.PcmFlushBytes());
 
         if (selection.Source == AudioSourceSelection.Process && selection.ProcessSelection != null)
         {
@@ -94,7 +107,7 @@ public sealed class PipelineRunner : IDisposable
                 selection.ProcessSelection.Pid, selection.ProcessSelection.Name);
             try
             {
-                var plb = new ProcessLoopbackSource(selection.ProcessSelection.Pid);
+                var plb = new ProcessLoopbackSource(selection.ProcessSelection.Pid, captureBufferMs: LatencyMode.CaptureBufferMs());
                 plb.Start();
                 _audioSource = plb;
             }
@@ -108,7 +121,7 @@ public sealed class PipelineRunner : IDisposable
         }
         else
         {
-            var wsl = new WasapiLoopbackSource();
+            var wsl = new WasapiLoopbackSource(LatencyMode.CaptureBufferMs());
             wsl.Start();
             _audioSource = wsl;
         }
@@ -123,7 +136,11 @@ public sealed class PipelineRunner : IDisposable
         // thread. StartAsync is typically invoked on the UI STA thread.
 
         _framesEmitted = 0;
+        _lastSlowWriteCount = 0;
         _pipelineStart = DateTime.UtcNow;
+        StartedAtUtc = _pipelineStart;
+        FirstChunkAtUtc = null;
+        FirstClientAtUtc = null;
         _lastFrameLog = _pipelineStart;
         _pumpTask = Task.Run(() => PumpLoopAsync(token), token);
 
@@ -135,6 +152,11 @@ public sealed class PipelineRunner : IDisposable
                 {
                     await Task.Delay(500, token).ConfigureAwait(false);
                     ClientCount = _broadcast.SubscriberCount;
+                    if (ClientCount > 0 && FirstClientAtUtc == null)
+                    {
+                        FirstClientAtUtc = DateTime.UtcNow;
+                        Log.Information("First Sonos client connected after {Ms:F0} ms", (FirstClientAtUtc.Value - _pipelineStart).TotalMilliseconds);
+                    }
                 }
                 catch (OperationCanceledException) { break; }
             }
@@ -162,11 +184,12 @@ public sealed class PipelineRunner : IDisposable
 
         var port = _streamServer.LocalEndPoint.Port;
         var streamUrl = _streamServer.StreamUrl($"{SsdpDiscovery.FormatHost(localIp)}:{port}");
+        CurrentStreamUrl = streamUrl;
         Log.Information("Instructing {Name} to stream from {Url} format={Format} contentType={ContentType} radioScheme={RadioScheme}",
             device.FriendlyName, streamUrl, Format, Format.ContentType(), !Format.IsPcm());
 
         var sonos = new SonosController();
-        await sonos.SetUriAndPlayAsync(device, streamUrl, ct, useRadioScheme: !Format.IsPcm(), contentType: Format.MetadataMimeType()).ConfigureAwait(false);
+        await sonos.SetUriAndPlayAsync(device, streamUrl, ct, useRadioScheme: !Format.IsPcm(), contentType: Format.MetadataMimeType(), metadataTitle: BuildMetadataTitle(selection, device)).ConfigureAwait(false);
     }
 
     public async Task StopAsync(SonosDevice? device)
@@ -210,6 +233,7 @@ public sealed class PipelineRunner : IDisposable
 
         if (_streamServer != null)
         {
+            _lastSlowWriteCount = _streamServer.SlowWriteCount;
             await _streamServer.ShutdownAsync().ConfigureAwait(false);
             _streamServer.Dispose();
             _streamServer = null;
@@ -224,6 +248,8 @@ public sealed class PipelineRunner : IDisposable
         _broadcast.CompleteAll();
         ClientCount = 0;
         CurrentMixFormat = null;
+        CurrentLocalIp = null;
+        CurrentStreamUrl = null;
 
         await sonosStop.ConfigureAwait(false);
         Log.Information("Pipeline stopped in {Ms:F0} ms", (DateTime.UtcNow - t0).TotalMilliseconds);
@@ -242,8 +268,8 @@ public sealed class PipelineRunner : IDisposable
                 StreamingFormat.Aac192 => new MfAacEncoder(192_000),
                 StreamingFormat.Aac256 => new MfAacEncoder(256_000),
                 StreamingFormat.Aac320 => new MfAacEncoder(320_000),
-                StreamingFormat.WavPcm => (IAudioEncoder)new LpcmEncoder(),
-                StreamingFormat.L16Pcm => new L16PcmEncoder(),
+                StreamingFormat.WavPcm => (IAudioEncoder)new LpcmEncoder(LatencyMode.PcmFlushBytes()),
+                StreamingFormat.L16Pcm => new L16PcmEncoder(LatencyMode.PcmFlushBytes()),
                 _                      => new MfAacEncoder(256_000),
             };
 
@@ -284,8 +310,13 @@ public sealed class PipelineRunner : IDisposable
                 var chunk = _encoder.FlushChunk();
                 if (!chunk.IsEmpty)
                 {
+                    if (FirstChunkAtUtc == null)
+                    {
+                        FirstChunkAtUtc = DateTime.UtcNow;
+                        Log.Information("First audio chunk emitted after {Ms:F0} ms", (FirstChunkAtUtc.Value - _pipelineStart).TotalMilliseconds);
+                    }
                     _broadcast.Write(chunk);
-                    _framesEmitted++;
+                    Interlocked.Increment(ref _framesEmitted);
                 }
 
                 var now = DateTime.UtcNow;
@@ -324,6 +355,14 @@ public sealed class PipelineRunner : IDisposable
     }
 
     public int ClientCount { get; private set; }
+
+    private static string BuildMetadataTitle(Selection selection, SonosDevice device)
+    {
+        var source = selection.Source == AudioSourceSelection.Process && selection.ProcessSelection != null
+            ? selection.ProcessSelection.Name
+            : "Whole system";
+        return $"RoomRelay - {source} to {device.FriendlyName}";
+    }
 
     private void UpdateClipping(ReadOnlySpan<float> samples)
     {

--- a/csharp/src/SonosStreaming.Core/Pipeline/StreamingLatencyMode.cs
+++ b/csharp/src/SonosStreaming.Core/Pipeline/StreamingLatencyMode.cs
@@ -1,0 +1,28 @@
+namespace SonosStreaming.Core.Pipeline;
+
+public enum StreamingLatencyMode
+{
+    Stable = 0,
+    LowLatency = 1,
+}
+
+public static class StreamingLatencyModeExtensions
+{
+    public static string DisplayName(this StreamingLatencyMode mode) => mode switch
+    {
+        StreamingLatencyMode.LowLatency => "Low latency",
+        _ => "Stable",
+    };
+
+    public static int CaptureBufferMs(this StreamingLatencyMode mode) => mode switch
+    {
+        StreamingLatencyMode.LowLatency => 50,
+        _ => 200,
+    };
+
+    public static int PcmFlushBytes(this StreamingLatencyMode mode) => mode switch
+    {
+        StreamingLatencyMode.LowLatency => 4096,
+        _ => 8192,
+    };
+}

--- a/csharp/src/SonosStreaming.Core/State/AppSettings.cs
+++ b/csharp/src/SonosStreaming.Core/State/AppSettings.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Serilog;
 using SonosStreaming.Core.Audio;
+using SonosStreaming.Core.Pipeline;
 
 namespace SonosStreaming.Core.State;
 
@@ -33,6 +34,9 @@ public sealed class AppSettings : IDisposable
     public float DelayMsR { get; set; } = 0.0f;
     public string? LastSpeakerUdn { get; set; }
     public StreamingFormat StreamingFormat { get; set; } = StreamingFormat.Aac256;
+    public StreamingLatencyMode LatencyMode { get; set; } = StreamingLatencyMode.Stable;
+    public string? LastProcessName { get; set; }
+    public List<AppProcessPreference> ProcessPreferences { get; set; } = new();
     public ThemePreference ThemePreference { get; set; } = ThemePreference.System;
     public List<ManualSpeakerEndpoint> ManualSpeakerEndpoints { get; set; } = new();
 
@@ -49,6 +53,7 @@ public sealed class AppSettings : IDisposable
             var json = File.ReadAllText(SettingsPath);
             var settings = JsonSerializer.Deserialize<AppSettings>(json, JsonOpts) ?? new AppSettings();
             settings.ManualSpeakerEndpoints ??= [];
+            settings.ProcessPreferences ??= [];
             return settings;
         }
         catch (Exception ex)
@@ -106,4 +111,11 @@ public sealed record ManualSpeakerEndpoint
     public string Ip { get; init; } = "";
     public ushort Port { get; init; } = 1400;
     public string DisplayName => $"{Ip}:{Port}";
+}
+
+public sealed record AppProcessPreference
+{
+    public string ProcessName { get; init; } = "";
+    public StreamingFormat StreamingFormat { get; set; } = StreamingFormat.Aac256;
+    public StreamingLatencyMode LatencyMode { get; set; } = StreamingLatencyMode.Stable;
 }

--- a/csharp/tests/SonosStreaming.Tests/AppSettingsTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/AppSettingsTests.cs
@@ -1,4 +1,5 @@
 using SonosStreaming.Core.Audio;
+using SonosStreaming.Core.Pipeline;
 using SonosStreaming.Core.State;
 using FluentAssertions;
 using Xunit;
@@ -51,6 +52,12 @@ public class AppSettingsTests : IDisposable
             DelayMsL = 10.0f,
             DelayMsR = 5.0f,
             LastSpeakerUdn = "uuid:test-speaker",
+            LastProcessName = "vlc",
+            LatencyMode = StreamingLatencyMode.LowLatency,
+            ProcessPreferences =
+            [
+                new AppProcessPreference { ProcessName = "vlc", StreamingFormat = StreamingFormat.WavPcm, LatencyMode = StreamingLatencyMode.LowLatency },
+            ],
             ManualSpeakerEndpoints =
             [
                 new ManualSpeakerEndpoint { Ip = "192.168.1.50", Port = 1400 },
@@ -72,6 +79,9 @@ public class AppSettingsTests : IDisposable
         loaded.DelayMsL.Should().Be(10.0f);
         loaded.DelayMsR.Should().Be(5.0f);
         loaded.LastSpeakerUdn.Should().Be("uuid:test-speaker");
+        loaded.LastProcessName.Should().Be("vlc");
+        loaded.LatencyMode.Should().Be(StreamingLatencyMode.LowLatency);
+        loaded.ProcessPreferences.Should().BeEquivalentTo(original.ProcessPreferences);
         loaded.ManualSpeakerEndpoints.Should().BeEquivalentTo(original.ManualSpeakerEndpoints);
     }
 
@@ -125,5 +135,14 @@ public class AppSettingsTests : IDisposable
 
         loaded.ThemePreference.Should().Be(ThemePreference.Dark);
         original.Dispose();
+    }
+
+    [Fact]
+    public void Load_WithNoFile_DefaultsToStableLatency()
+    {
+        var s = AppSettings.Load();
+
+        s.LatencyMode.Should().Be(StreamingLatencyMode.Stable);
+        s.ProcessPreferences.Should().BeEmpty();
     }
 }

--- a/csharp/tests/SonosStreaming.Tests/L16PcmEncoderTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/L16PcmEncoderTests.cs
@@ -33,6 +33,17 @@ public sealed class L16PcmEncoderTests
     }
 
     [Fact]
+    public void Encode_LowLatencyThreshold_FlushesEarlier()
+    {
+        using var enc = new L16PcmEncoder(minFlushBytes: 4096);
+
+        for (int i = 0; i < 5; i++)
+            enc.Encode(MakeFrame(new short[480]));
+
+        enc.FlushChunk().Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
     public void Dispose_ThenEncode_ThrowsObjectDisposedException()
     {
         var enc = new L16PcmEncoder();

--- a/csharp/tests/SonosStreaming.Tests/LpcmEncoderTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/LpcmEncoderTests.cs
@@ -34,6 +34,16 @@ public class LpcmEncoderTests
     }
 
     [Fact]
+    public void Encode_LowLatencyThreshold_FlushesEarlier()
+    {
+        using var enc = new LpcmEncoder(minFlushBytes: 4096);
+        for (int i = 0; i < 5; i++)
+            enc.Encode(MakeFrame(new short[480]));
+
+        enc.FlushChunk().Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
     public void Drain_FlushesAllRemainingData()
     {
         using var enc = new LpcmEncoder();


### PR DESCRIPTION
## Summary
- Add Stable/Low Latency streaming modes for PCM formats and persist per-app format/latency preferences.
- Improve per-application capture UX with broader media-player detection, whole-system fallback, top-level notifications, and richer diagnostics.
- Polish the release UI/docs with compact default sizing, status-bar trimming, README updates, and v1.0.6 metadata.

## Testing
- `dotnet test tests\SonosStreaming.Tests\SonosStreaming.Tests.csproj -c Release`