### PR TITLE
Improve per-app capture diagnostics and scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,17 @@ Install RoomRelay from the installer, or extract the ZIP and run
   11 builds.
 - Some browsers, protected media apps, elevated processes, system apps, and
   short-lived sessions may not be capturable.
+- If the per-app list is empty, start playback in the target app, wait a few
+  seconds, then click **Refresh apps**.
+- Enable **Show all audio sessions** to reveal advanced entries that RoomRelay
+  normally hides. These entries can help diagnose empty-list reports, but some
+  of them may still fail Windows process-loopback capture.
+- Use **Whole system** mode when the target app does not appear or cannot be
+  captured per-application.
 - RoomRelay remembers the last selected app by process name and restores that
   app's preferred format and latency mode when it appears again.
+- Diagnostics packages include the latest per-app enumeration counts, including
+  total sessions, filtered sessions, system sessions, and kept app sessions.
 
 ## Compared with other approaches
 

--- a/csharp/src/SonosStreaming.App/Services/DiagnosticsPackageService.cs
+++ b/csharp/src/SonosStreaming.App/Services/DiagnosticsPackageService.cs
@@ -4,6 +4,7 @@ using System.Net.NetworkInformation;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using SonosStreaming.Core.Audio;
 using SonosStreaming.Core.Pipeline;
 using SonosStreaming.Core.State;
 
@@ -27,7 +28,12 @@ public sealed class DiagnosticsPackageService
         }
     }
 
-    public string CreatePackage(AppCore core, PipelineRunner pipeline, AppSettings settings, string? lastError)
+    public string CreatePackage(
+        AppCore core,
+        PipelineRunner pipeline,
+        AppSettings settings,
+        string? lastError,
+        AudioProcessEnumerationResult? audioProcessEnumeration = null)
     {
         Directory.CreateDirectory(AppDataDir);
         Directory.CreateDirectory(DiagnosticsDir);
@@ -39,7 +45,7 @@ public sealed class DiagnosticsPackageService
         using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
         AddLogs(archive);
         AddFileIfExists(archive, Path.Combine(AppDataDir, "crash.txt"), "crash.txt");
-        AddText(archive, "diagnostics.txt", BuildDiagnostics(core, pipeline, settings, lastError));
+        AddText(archive, "diagnostics.txt", BuildDiagnostics(core, pipeline, settings, lastError, audioProcessEnumeration));
 
         return zipPath;
     }
@@ -81,7 +87,12 @@ public sealed class DiagnosticsPackageService
         writer.Write(contents);
     }
 
-    private static string BuildDiagnostics(AppCore core, PipelineRunner pipeline, AppSettings settings, string? lastError)
+    private static string BuildDiagnostics(
+        AppCore core,
+        PipelineRunner pipeline,
+        AppSettings settings,
+        string? lastError,
+        AudioProcessEnumerationResult? audioProcessEnumeration)
     {
         var selection = core.Selection;
         var sb = new StringBuilder();
@@ -113,6 +124,27 @@ public sealed class DiagnosticsPackageService
         sb.AppendLine($"Process preferences: {settings.ProcessPreferences.Count}");
         foreach (var pref in settings.ProcessPreferences)
             sb.AppendLine($"- {pref.ProcessName}: {pref.StreamingFormat}, {pref.LatencyMode}");
+        sb.AppendLine();
+        sb.AppendLine("Audio Process Enumeration");
+        if (audioProcessEnumeration == null)
+        {
+            sb.AppendLine("Last enumeration: n/a");
+        }
+        else
+        {
+            sb.AppendLine($"Include filtered sessions: {audioProcessEnumeration.IncludeFilteredSessions}");
+            sb.AppendLine($"Endpoints scanned: {audioProcessEnumeration.EndpointsScanned}");
+            sb.AppendLine($"Total sessions: {audioProcessEnumeration.TotalSessions}");
+            sb.AppendLine($"Expired skipped: {audioProcessEnumeration.ExpiredSkipped}");
+            sb.AppendLine($"Self skipped: {audioProcessEnumeration.SelfSkipped}");
+            sb.AppendLine($"System skipped: {audioProcessEnumeration.SystemSkipped}");
+            sb.AppendLine($"Filtered skipped: {audioProcessEnumeration.FilteredSkipped}");
+            sb.AppendLine($"Kept: {audioProcessEnumeration.Kept}");
+            sb.AppendLine($"Last error: {audioProcessEnumeration.LastError ?? "n/a"}");
+            foreach (var process in audioProcessEnumeration.Processes)
+                sb.AppendLine($"- {process.DisplayName} ({process.Name}, pid={process.Pid})");
+        }
+        sb.AppendLine();
         sb.AppendLine($"Clients: {pipeline.ClientCount}");
         sb.AppendLine($"Local stream IP: {pipeline.CurrentLocalIp?.ToString() ?? "n/a"}");
         sb.AppendLine($"Stream URL: {pipeline.CurrentStreamUrl ?? "n/a"}");

--- a/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
+++ b/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
@@ -27,6 +27,8 @@ public sealed partial class MainViewModel : ObservableObject
 
     public ObservableCollection<AudioProcess> AudioProcesses { get; } = new();
 
+    public AudioProcessEnumerationResult? LastAudioProcessEnumeration { get; private set; }
+
     [ObservableProperty]
     public partial string StateLabel { get; set; }
 
@@ -93,6 +95,12 @@ public sealed partial class MainViewModel : ObservableObject
 
     [ObservableProperty]
     public partial AudioProcess? SelectedProcess { get; set; }
+
+    [ObservableProperty]
+    public partial bool ShowAllAudioSessions { get; set; }
+
+    [ObservableProperty]
+    public partial string AudioProcessStatus { get; set; }
 
     [ObservableProperty]
     public partial bool IsProcessSourceSelected { get; set; }
@@ -227,6 +235,7 @@ public sealed partial class MainViewModel : ObservableObject
         EqHighDb = settings.EqHighDb;
         DelayMsL = settings.DelayMsL;
         DelayMsR = settings.DelayMsR;
+        AudioProcessStatus = "Looking for app audio sessions...";
         ErrorMessage = "";
         NotificationTitle = "";
         NotificationSeverity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error;
@@ -478,6 +487,14 @@ public sealed partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(IsWholeSystemSourceSelected));
     }
 
+    partial void OnShowAllAudioSessionsChanged(bool value)
+    {
+        AudioProcessStatus = value
+            ? "Showing all non-system audio sessions. Some entries may not support per-app capture."
+            : "Showing likely user-facing audio apps only.";
+        _ = RefreshAudioProcessesAsync();
+    }
+
     // Starts a background task that refreshes the AudioProcesses collection
     // every 2s so apps opening/closing their audio sessions appear in the
     // combo without requiring a manual Rescan. Must be called from the UI
@@ -494,8 +511,8 @@ public sealed partial class MainViewModel : ObservableObject
             {
                 try
                 {
-                    var procs = ProcessLoopbackSource.EnumerateActiveAudioProcesses();
-                    _dq?.TryEnqueue(() => SyncAudioProcesses(procs));
+                    var enumeration = ProcessLoopbackSource.EnumerateActiveAudioProcessesWithDiagnostics(ShowAllAudioSessions);
+                    _dq?.TryEnqueue(() => SyncAudioProcessEnumeration(enumeration));
                 }
                 catch (Exception ex)
                 {
@@ -504,6 +521,13 @@ public sealed partial class MainViewModel : ObservableObject
                 try { await Task.Delay(2000, ct); } catch (OperationCanceledException) { break; }
             }
         }, ct);
+    }
+
+    private void SyncAudioProcessEnumeration(AudioProcessEnumerationResult enumeration)
+    {
+        LastAudioProcessEnumeration = enumeration;
+        SyncAudioProcesses(enumeration.Processes);
+        UpdateAudioProcessStatus(enumeration);
     }
 
     // Diffs the incoming list against AudioProcesses and adds/removes
@@ -529,6 +553,67 @@ public sealed partial class MainViewModel : ObservableObject
             var previous = AudioProcesses.FirstOrDefault(p => string.Equals(p.Name, Settings.LastProcessName, StringComparison.OrdinalIgnoreCase));
             if (previous != null)
                 SelectedProcess = previous;
+        }
+
+        StartCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(SourceStatusLabel));
+    }
+
+    private void UpdateAudioProcessStatus(AudioProcessEnumerationResult enumeration)
+    {
+        if (!string.IsNullOrWhiteSpace(enumeration.LastError))
+        {
+            AudioProcessStatus = $"Could not read app audio sessions: {enumeration.LastError}";
+            return;
+        }
+
+        if (enumeration.TotalSessions == 0)
+        {
+            AudioProcessStatus = "No Windows audio sessions found. Start playback in the app, wait a few seconds, or use Whole system.";
+            return;
+        }
+
+        if (enumeration.Kept == 0 && enumeration.FilteredSkipped > 0 && !enumeration.IncludeFilteredSessions)
+        {
+            AudioProcessStatus = $"Found {FormatCount(enumeration.TotalSessions, "audio session")}, but none matched the app filter. Try Refresh apps or enable Show all audio sessions.";
+            return;
+        }
+
+        if (enumeration.Kept == 0)
+        {
+            AudioProcessStatus = $"Found {FormatCount(enumeration.TotalSessions, "audio session")}, but only system, expired, or RoomRelay sessions were available.";
+            return;
+        }
+
+        var mode = enumeration.IncludeFilteredSessions ? " including advanced entries" : "";
+        AudioProcessStatus = $"Found {FormatCount(enumeration.Kept, "app audio session")}{mode}.";
+    }
+
+    private static string FormatCount(int count, string noun) => count == 1 ? $"1 {noun}" : $"{count} {noun}s";
+
+    [RelayCommand]
+    public async Task RefreshAudioProcessesAsync()
+    {
+        try
+        {
+            var includeFiltered = ShowAllAudioSessions;
+            var enumeration = await Task.Run(() => ProcessLoopbackSource.EnumerateActiveAudioProcessesWithDiagnostics(includeFiltered));
+            SyncAudioProcessEnumeration(enumeration);
+            Log.Information(
+                "Audio process refresh: endpoints={Endpoints}, sessions={Sessions}, system={System}, filtered={Filtered}, self={Self}, expired={Expired}, kept={Kept}, includeFiltered={IncludeFiltered}",
+                enumeration.EndpointsScanned,
+                enumeration.TotalSessions,
+                enumeration.SystemSkipped,
+                enumeration.FilteredSkipped,
+                enumeration.SelfSkipped,
+                enumeration.ExpiredSkipped,
+                enumeration.Kept,
+                enumeration.IncludeFilteredSessions);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to refresh audio processes");
+            AudioProcessStatus = $"Could not refresh app audio sessions: {ex.Message}";
         }
     }
 
@@ -612,9 +697,9 @@ public sealed partial class MainViewModel : ObservableObject
 
         try
         {
-            var procs = ProcessLoopbackSource.EnumerateActiveAudioProcesses();
-            SyncAudioProcesses(procs);
-            Log.Information("Found {Count} active audio process(es)", procs.Count);
+            var enumeration = ProcessLoopbackSource.EnumerateActiveAudioProcessesWithDiagnostics(ShowAllAudioSessions);
+            SyncAudioProcessEnumeration(enumeration);
+            Log.Information("Found {Count} active audio process(es)", enumeration.Kept);
         }
         catch (Exception ex)
         {
@@ -706,6 +791,13 @@ public sealed partial class MainViewModel : ObservableObject
             _core.SetSource(selection, process);
         }
         catch (Exception ex) { Log.Warning(ex, "Cannot change source"); }
+    }
+
+    [RelayCommand]
+    public void UseWholeSystemSource()
+    {
+        IsProcessSourceSelected = false;
+        SelectSource(AudioSourceSelection.WholeSystem);
     }
 
     [RelayCommand]
@@ -968,7 +1060,12 @@ public sealed partial class MainViewModel : ObservableObject
     {
         try
         {
-            var package = _diagnostics.CreatePackage(_core, Pipeline, Settings, string.IsNullOrWhiteSpace(ErrorMessage) ? null : ErrorMessage);
+            var package = _diagnostics.CreatePackage(
+                _core,
+                Pipeline,
+                Settings,
+                string.IsNullOrWhiteSpace(ErrorMessage) ? null : ErrorMessage,
+                LastAudioProcessEnumeration);
             DiagnosticsStatus = $"Diagnostics package created: {package}";
             Log.Information("Diagnostics package created at {Path}", package);
             _diagnostics.OpenDiagnosticsPackage(package);

--- a/csharp/src/SonosStreaming.App/Views/MainPage.xaml
+++ b/csharp/src/SonosStreaming.App/Views/MainPage.xaml
@@ -108,7 +108,7 @@
             CloseButtonClick="ErrorInfoBar_CloseButtonClick" />
 
         <!-- Left panel -->
-        <ScrollViewer Grid.Row="2" Grid.Column="0" VerticalScrollMode="Auto">
+        <ScrollViewer x:Name="LeftPaneScrollViewer" Grid.Row="2" Grid.Column="0" VerticalScrollMode="Auto">
             <StackPanel Spacing="16">
 
                 <!-- Speakers -->
@@ -221,14 +221,34 @@
                         <RadioButton x:Name="WholeSystemRadio" Content="Whole system" GroupName="Source" IsChecked="{x:Bind ViewModel.IsWholeSystemSourceSelected, Mode=OneWay}" Checked="WholeSystemRadio_Checked" />
                         <RadioButton x:Name="ProcessRadio" Content="Per application" GroupName="Source" IsChecked="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay}" Checked="ProcessRadio_Checked" />
                         <TextBlock Text="Per-application capture uses Windows process loopback and works best on current Windows 11 builds. Use Whole system if an app does not appear or cannot start." TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <ComboBox
-                            ItemsSource="{x:Bind ViewModel.AudioProcesses, Mode=OneWay}"
-                            SelectedItem="{x:Bind ViewModel.SelectedProcess, Mode=TwoWay}"
-                            DisplayMemberPath="DisplayName"
-                            PlaceholderText="Select application"
-                            IsEnabled="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay}"
-                            MaxHeight="200"
-                            HorizontalAlignment="Stretch" />
+                        <Grid ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ComboBox
+                                ItemsSource="{x:Bind ViewModel.AudioProcesses, Mode=OneWay}"
+                                SelectedItem="{x:Bind ViewModel.SelectedProcess, Mode=TwoWay}"
+                                DisplayMemberPath="DisplayName"
+                                PlaceholderText="Select application"
+                                IsEnabled="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay}"
+                                MaxHeight="200"
+                                HorizontalAlignment="Stretch" />
+                            <Button
+                                Grid.Column="1"
+                                Content="Refresh apps"
+                                Command="{x:Bind ViewModel.RefreshAudioProcessesCommand}"
+                                IsEnabled="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay}" />
+                        </Grid>
+                        <CheckBox
+                            Content="Show all audio sessions"
+                            IsChecked="{x:Bind ViewModel.ShowAllAudioSessions, Mode=TwoWay}"
+                            IsEnabled="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay}" />
+                        <TextBlock Text="{x:Bind ViewModel.AudioProcessStatus, Mode=OneWay}" TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <Button
+                            Content="Use whole system instead"
+                            Command="{x:Bind ViewModel.UseWholeSystemSourceCommand}"
+                            Visibility="{x:Bind ViewModel.IsProcessSourceSelected, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                         <TextBlock Text="{x:Bind ViewModel.SourceStatusLabel, Mode=OneWay}" TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         <TextBlock Text="Format" Margin="0,8,0,0" />
                         <TextBlock Text="AAC is the stable default with Sonos buffering latency. LPCM is lower-latency, high-bandwidth, and experimental." TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -285,7 +305,7 @@
         </ScrollViewer>
 
         <!-- Right panel -->
-        <ScrollViewer Grid.Row="2" Grid.Column="2" VerticalScrollMode="Auto" HorizontalScrollMode="Disabled">
+        <ScrollViewer x:Name="RightPaneScrollViewer" Grid.Row="2" Grid.Column="2" VerticalScrollMode="Auto" HorizontalScrollMode="Disabled">
             <StackPanel Spacing="16">
 
                 <!-- Levels -->

--- a/csharp/src/SonosStreaming.App/Views/MainPage.xaml.cs
+++ b/csharp/src/SonosStreaming.App/Views/MainPage.xaml.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using SonosStreaming.App.ViewModels;
 using SonosStreaming.Core.Audio;
 using SonosStreaming.Core.State;
@@ -16,7 +18,35 @@ public sealed partial class MainPage : Page
         ViewModel = App.Current.Services.GetRequiredService<MainViewModel>();
         DataContext = ViewModel;
         InitializeComponent();
+        LeftPaneScrollViewer.AddHandler(PointerWheelChangedEvent, new PointerEventHandler(OnPanePointerWheelChanged), true);
+        RightPaneScrollViewer.AddHandler(PointerWheelChangedEvent, new PointerEventHandler(OnPanePointerWheelChanged), true);
         Loaded += async (_, _) => await ViewModel.RescanCommand.ExecuteAsync(null);
+    }
+
+    private void OnPanePointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not ScrollViewer scrollViewer) return;
+        if (IsInsideOpenComboBox(e.OriginalSource as DependencyObject)) return;
+
+        var delta = e.GetCurrentPoint(scrollViewer).Properties.MouseWheelDelta;
+        if (delta == 0) return;
+
+        var targetOffset = Math.Clamp(scrollViewer.VerticalOffset - delta, 0, scrollViewer.ScrollableHeight);
+        if (Math.Abs(targetOffset - scrollViewer.VerticalOffset) < 0.1) return;
+
+        scrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
+        e.Handled = true;
+    }
+
+    private static bool IsInsideOpenComboBox(DependencyObject? source)
+    {
+        for (var current = source; current != null; current = VisualTreeHelper.GetParent(current))
+        {
+            if (current is ComboBox { IsDropDownOpen: true })
+                return true;
+        }
+
+        return false;
     }
 
     private void WholeSystemRadio_Checked(object sender, RoutedEventArgs e)

--- a/csharp/src/SonosStreaming.Core/Audio/ProcessLoopbackSource.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/ProcessLoopbackSource.cs
@@ -9,6 +9,20 @@ namespace SonosStreaming.Core.Audio;
 
 public sealed record AudioProcess(int Pid, string Name, string DisplayName);
 
+public sealed record AudioProcessEnumerationResult
+{
+    public List<AudioProcess> Processes { get; init; } = new();
+    public int EndpointsScanned { get; init; }
+    public int TotalSessions { get; init; }
+    public int ExpiredSkipped { get; init; }
+    public int SelfSkipped { get; init; }
+    public int SystemSkipped { get; init; }
+    public int FilteredSkipped { get; init; }
+    public bool IncludeFilteredSessions { get; init; }
+    public string? LastError { get; init; }
+    public int Kept => Processes.Count;
+}
+
 public enum ProcessLoopbackMode
 {
     IncludeProcessTree,
@@ -229,13 +243,19 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
     [DllImport("Ole32.dll", ExactSpelling = true)]
     private static extern int CoCreateInstance(in Guid rclsid, IntPtr pUnkOuter, uint dwClsContext, in Guid riid, out IntPtr ppv);
 
-    public static unsafe List<AudioProcess> EnumerateActiveAudioProcesses()
+    public static List<AudioProcess> EnumerateActiveAudioProcesses() =>
+        EnumerateActiveAudioProcessesWithDiagnostics(includeFilteredSessions: false).Processes;
+
+    public static unsafe AudioProcessEnumerationResult EnumerateActiveAudioProcessesWithDiagnostics(bool includeFilteredSessions = false)
     {
         var result = new List<AudioProcess>();
         int totalSessions = 0;
         int expiredSkipped = 0;
-        int systemPidSkipped = 0;
+        int selfSkipped = 0;
+        int systemSkipped = 0;
+        int filteredSkipped = 0;
         int endpointsScanned = 0;
+        string? lastError = null;
         try
         {
             int hr = CoCreateInstance(CLSID_MMDeviceEnumerator, IntPtr.Zero, 1u, IID_IMMDeviceEnumerator, out var pEnum);
@@ -273,12 +293,12 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                                             var control2 = (IAudioSessionControl2)session;
                                             control2.GetProcessId(out var pidU);
                                             int pid = (int)pidU;
-                                            if (pid == 0) { systemPidSkipped++; continue; }
+                                            if (pid == 0) { systemSkipped++; continue; }
 
                                             AudioSessionState state;
                                             session.GetState(&state);
                                             if (state == AudioSessionState.AudioSessionStateExpired) { expiredSkipped++; continue; }
-                                            if (pid == Environment.ProcessId) { continue; }
+                                            if (pid == Environment.ProcessId) { selfSkipped++; continue; }
 
                                             string? sessionName = null;
                                             try
@@ -294,13 +314,22 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
                                             catch { }
 
                                             var (processName, friendlyName) = GetProcessLabels(pid);
-                                            if (!IsUserFacingProcess(pid, processName, sessionName, friendlyName))
+                                            if (IsHardSystemProcess(pid, processName))
                                             {
-                                                systemPidSkipped++;
-                                                Log.Verbose("Skipping audio session pid={Pid} process={Process} session={Session} friendly={Friendly}",
+                                                systemSkipped++;
+                                                Log.Verbose("Skipping system audio session pid={Pid} process={Process} session={Session} friendly={Friendly}",
                                                     pid, processName ?? "n/a", sessionName ?? "n/a", friendlyName ?? "n/a");
                                                 continue;
                                             }
+
+                                            if (!includeFilteredSessions && !IsUserFacingProcess(pid, processName, sessionName, friendlyName))
+                                            {
+                                                filteredSkipped++;
+                                                Log.Verbose("Filtering audio session pid={Pid} process={Process} session={Session} friendly={Friendly}",
+                                                    pid, processName ?? "n/a", sessionName ?? "n/a", friendlyName ?? "n/a");
+                                                continue;
+                                            }
+
                                             string displayName = !string.IsNullOrEmpty(sessionName)
                                                 ? sessionName
                                                 : (friendlyName ?? processName ?? $"pid {pid}");
@@ -323,23 +352,39 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
         }
         catch (Exception ex)
         {
+            lastError = ex.Message;
             Log.Warning(ex, "Failed to enumerate audio sessions");
         }
 
         var deduped = result.DistinctBy(p => p.Pid).OrderBy(p => p.DisplayName).ToList();
-        Log.Debug("Audio sessions: {Endpoints} endpoints, {Total} total sessions, {SysSkip} system, {ExpSkip} expired, {Kept} kept",
-            endpointsScanned, totalSessions, systemPidSkipped, expiredSkipped, deduped.Count);
-        return deduped;
+        Log.Debug("Audio sessions: {Endpoints} endpoints, {Total} total sessions, {SysSkip} system, {FilteredSkip} filtered, {SelfSkip} self, {ExpSkip} expired, {Kept} kept, includeFiltered={IncludeFiltered}",
+            endpointsScanned, totalSessions, systemSkipped, filteredSkipped, selfSkipped, expiredSkipped, deduped.Count, includeFilteredSessions);
+        return new AudioProcessEnumerationResult
+        {
+            Processes = deduped,
+            EndpointsScanned = endpointsScanned,
+            TotalSessions = totalSessions,
+            ExpiredSkipped = expiredSkipped,
+            SelfSkipped = selfSkipped,
+            SystemSkipped = systemSkipped,
+            FilteredSkipped = filteredSkipped,
+            IncludeFilteredSessions = includeFilteredSessions,
+            LastError = lastError,
+        };
     }
 
-    private static readonly string[] SystemProcessNames = new[]
+    private static readonly string[] HardSystemProcessNames = new[]
     {
         // Windows core
         "svchost", "csrss", "smss", "services", "lsass", "wininit", "winlogon",
         "dwm", "fontdrvhost", "conhost", "sihost", "taskhostw", "backgroundtaskhost",
         "runtimebroker", "dllhost", "wmiprvse", "searchindexer", "securityhealthservice",
         "ctfmon", "spoolsv", "audiodg", "musnotify", "wlanext", "vpnclient",
-        "searchhost", "textinputhost", "shellexperiencehost", "startmenuexperiencehost",
+        "searchhost", "textinputhost", "shellexperiencehost", "startmenuexperiencehost"
+    };
+
+    private static readonly string[] DefaultHiddenProcessNames = new[]
+    {
         // Terminals / shells
         "windowsterminal", "wt", "cmd", "powershell", "pwsh",
         // IDEs / dev tools
@@ -370,24 +415,11 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
     {
         if (string.IsNullOrEmpty(processName)) return false;
         if (IsKnownMediaProcess(processName) || IsKnownMediaLabel(sessionName) || IsKnownMediaLabel(friendlyName)) return true;
-        if (SystemProcessNames.Contains(processName, StringComparer.OrdinalIgnoreCase)) return false;
+        if (DefaultHiddenProcessNames.Contains(processName, StringComparer.OrdinalIgnoreCase)) return false;
 
         try
         {
             using var proc = Process.GetProcessById(pid);
-
-            // If the executable lives under C:\Windows it's a system component.
-            try
-            {
-                var path = proc.MainModule?.FileName;
-                if (!string.IsNullOrEmpty(path))
-                {
-                    var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-                    if (path.StartsWith(windows, StringComparison.OrdinalIgnoreCase))
-                        return false;
-                }
-            }
-            catch { /* Access denied to MainModule for protected processes — fall through */ }
 
             // A user-facing app typically has a visible main window.
             if (proc.MainWindowHandle != IntPtr.Zero) return true;
@@ -396,6 +428,26 @@ public sealed unsafe class ProcessLoopbackSource : WasapiCaptureBase
             if (!string.IsNullOrWhiteSpace(proc.MainWindowTitle)) return true;
 
             return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsHardSystemProcess(int pid, string? processName)
+    {
+        if (string.IsNullOrEmpty(processName)) return false;
+        if (HardSystemProcessNames.Contains(processName, StringComparer.OrdinalIgnoreCase)) return true;
+
+        try
+        {
+            using var proc = Process.GetProcessById(pid);
+            var path = proc.MainModule?.FileName;
+            if (string.IsNullOrEmpty(path)) return false;
+
+            var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            return path.StartsWith(windows, StringComparison.OrdinalIgnoreCase);
         }
         catch
         {


### PR DESCRIPTION
## Summary
- Add per-app audio session diagnostics, empty-state guidance, manual refresh, and a Show all audio sessions advanced option.
- Add a visible Whole system fallback action when per-app capture has no selectable target.
- Improve mouse-wheel routing across both UI panes and document per-app troubleshooting steps.

## Testing
- `dotnet test tests\SonosStreaming.Tests\SonosStreaming.Tests.csproj -c Release`