### PR TITLE
Prepare 1.0.7 for .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
         uses: actions/cache@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj/
 # IDE / Tooling
 .idea/
 .vscode/
+.dotnet10/
 TestResults/
 
 # OS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-RoomRelay is a Windows-only .NET 9 / WinUI 3 application that captures
+RoomRelay is a Windows-only .NET 10 / WinUI 3 application that captures
 system audio via WASAPI loopback and streams it to Sonos speakers as AAC-LC
 over HTTP.
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ WinUI 3 window with Mica backdrop and declarative XAML UI:
 
 ### Prerequisites
 
-- **.NET 9 SDK** (9.0.313 or later).
-- **Windows App Runtime 1.8** framework package (pre-installed on most
-  Windows 11; run `Get-AppxPackage *WindowsAppRuntime.1.8*` to check).
+- **.NET 10 SDK**.
+- **Windows App Runtime 2.0** framework package (run
+  `Get-AppxPackage *WindowsAppRuntime.2.0*` to check).
 - That's it — no extra DLLs to drop in.
 
 ### Build & run
@@ -285,7 +285,7 @@ the network profile where your Sonos lives so it can fetch the stream.
 ```
 csharp/
   SonosStreaming.sln
-  Directory.Build.props        # net9.0-windows, x64, unsafe, C# preview
+  Directory.Build.props        # net10.0-windows, x64, unsafe, C# preview
   src/
     SonosStreaming.Core/        # audio, network, DSP, pipeline
       Audio/                    # WASAPI capture, MF encoder, resampler, DSP

--- a/csharp/AGENTS.md
+++ b/csharp/AGENTS.md
@@ -1,10 +1,10 @@
-# AGENTS.md — C# / .NET 9 WinUI3 RoomRelay
+# AGENTS.md — C# / .NET 10 WinUI3 RoomRelay
 
 Guidance for working in the C# implementation.
 
 ## What this is
 
-Windows-only .NET 9 / WinUI 3 desktop app that:
+Windows-only .NET 10 / WinUI 3 desktop app that:
 
 - Captures system audio via WASAPI loopback (raw CsWin32; no NAudio).
 - Resamples / converts to 48 kHz s16 stereo (pure C# pass-through when the
@@ -35,13 +35,13 @@ dotnet test                                   # run unit + integration tests
 ```
 
 **Prerequisites:**
-- .NET 9 SDK (9.0.313 or later).
-- Windows App Runtime 1.8 framework package (pre-installed on most Windows 11;
-  run `Get-AppxPackage *WindowsAppRuntime.1.8*` to check).
+- .NET 10 SDK.
+- Windows App Runtime 2.0 framework package (run
+  `Get-AppxPackage *WindowsAppRuntime.2.0*` to check).
 
 The project uses **framework-dependent** deployment (`WindowsAppSDKSelfContained=false`,
 `WindowsPackageType=None`) with a **custom `Program.cs`** entry point (`DISABLE_XAML_GENERATED_MAIN`).
-The Windows App Runtime is resolved via `Bootstrap.Initialize(0x00010008)` at
+The Windows App Runtime is resolved via `Bootstrap.Initialize(0x00020000)` at
 startup — this must happen before any WinUI types are touched.
 
 The app binds `0.0.0.0:8000` and sends SSDP multicast on first scan — a firewall
@@ -52,7 +52,7 @@ prompt is expected on first run.
 ```
 csharp/
   SonosStreaming.sln
-  Directory.Build.props                  # shared: net9.0-win, x64, unsafe, C# preview
+  Directory.Build.props                  # shared: net10.0-win, x64, unsafe, C# preview
   src/
     SonosStreaming.Core/                  # .NET library — audio, network, state, pipeline
       NativeMethods.txt                   # CsWin32 bindings list (Core)
@@ -155,7 +155,7 @@ WASAPI capture thread → PcmFrameF32 → DSP (gain → EQ → delay → volume 
 
 ## Key decisions & gotchas
 
-1. **WinUI 3 unpackaged bootstrap.** Call `Bootstrap.Initialize(0x00010008)`
+1. **WinUI 3 unpackaged bootstrap.** Call `Bootstrap.Initialize(0x00020000)`
    **before** any WinUI types are used, and create `new App()` **inside**
    the `Application.Start` callback (creating it before causes
    `RPC_E_WRONG_THREAD`). The generated `ApplicationConfiguration.Initialize()`
@@ -168,7 +168,7 @@ WASAPI capture thread → PcmFrameF32 → DSP (gain → EQ → delay → volume 
    initializes the system runtime, two copies load in the same process and
    trigger a native FailFast at `Application.Start`. Use
    `WindowsAppSDKSelfContained=false` and rely on the system-installed
-   Windows App Runtime 1.8 framework package.
+   Windows App Runtime 2.0 framework package.
 
 3. **MF AAC encoder needs payload type 1 for ADTS.** The MFT can emit raw
    AAC (no framing) or ADTS. Sonos requires ADTS over HTTP, so we set
@@ -421,22 +421,22 @@ Unit tests use xUnit + FluentAssertions + FsCheck. The e2e test
 
 | Package                                 | Version          |
 |-----------------------------------------|------------------|
-| Microsoft.WindowsAppSDK                 | 1.8.260416003    |
-| CommunityToolkit.Mvvm                   | 8.4.0            |
-| H.NotifyIcon.WinUI                      | 2.2.0            |
-| Microsoft.Graphics.Win2D                | 1.3.1            |
+| Microsoft.WindowsAppSDK                 | 2.0.1            |
+| CommunityToolkit.Mvvm                   | 8.4.2            |
+| H.NotifyIcon.WinUI                      | 2.4.1            |
+| Microsoft.Graphics.Win2D                | 1.4.0            |
 | MathNet.Numerics                        | 5.0.0            |
-| Serilog                                 | 4.2.0            |
-| Serilog.Sinks.File                      | 6.0.0            |
-| Microsoft.Extensions.DependencyInjection | 9.0.0           |
-| Microsoft.Windows.CsWin32               | 0.3.162          |
-| System.Text.Json                        | 9.0.0            |
+| Serilog                                 | 4.3.1            |
+| Serilog.Sinks.File                      | 7.0.0            |
+| Microsoft.Extensions.DependencyInjection | 10.0.7          |
+| Microsoft.Windows.CsWin32               | 0.3.275          |
 
 ## Coding conventions
 
 - `Serilog` for logs; exceptions propagate naturally.
 - Windows-specific code in Core is not gated behind `#if WINDOWS` — the
-  whole project targets `net9.0-windows10.0.19041.0`.
+  whole project targets `net10.0-windows10.0.26100.0` with
+  `SupportedOSPlatformVersion=10.0.19041.0`.
 - `unsafe` blocks are allowed (`AllowUnsafeBlocks=true`) for COM and
   Media Foundation interop. Prefer marking individual methods `unsafe`
   rather than the whole class so `await` can still be used elsewhere
@@ -447,5 +447,5 @@ Unit tests use xUnit + FluentAssertions + FsCheck. The e2e test
   validation and hot reload support. Only custom controls built from
   primitives use imperative C#.
 - `.ConfigureAwait(false)` on every `await` in `SonosStreaming.Core`.
-- Prefer `Lock` over `object` for mutual exclusion (C# 13 `lock` statement
+- Prefer `Lock` over `object` for mutual exclusion (C# 14 `lock` statement
   works with both).

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <Platforms>x64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/csharp/installer/README.md
+++ b/csharp/installer/README.md
@@ -8,7 +8,7 @@ This folder contains an [Inno Setup](https://jrsoftware.org/isinfo.php) script t
 2. Publish the app:
    ```powershell
    cd ..\..\csharp
-   dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained true -p:WindowsAppSDKSelfContained=false -o publish\RoomRelay-v1.0.3
+   dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained true -p:WindowsAppSDKSelfContained=false -o publish\RoomRelay-v1.0.7
    ```
 
 ## Build the Installer
@@ -19,7 +19,7 @@ Open `installer.iss` in Inno Setup Compiler (or right-click → **Compile**), or
 iscc installer.iss
 ```
 
-The installer `RoomRelay-Setup-1.0.3.exe` will be created in `csharp\`.
+The installer `RoomRelay-Setup-1.0.7.exe` will be created in `csharp\`.
 
 ## What the Installer Does
 
@@ -32,7 +32,7 @@ The installer `RoomRelay-Setup-1.0.3.exe` will be created in `csharp\`.
 ## Silent Install (Enterprise/Deployment)
 
 ```powershell
-RoomRelay-Setup-1.0.3.exe /VERYSILENT /NORESTART
+RoomRelay-Setup-1.0.7.exe /VERYSILENT /NORESTART
 ```
 
 ## Size

--- a/csharp/src/SonosStreaming.App/Program.cs
+++ b/csharp/src/SonosStreaming.App/Program.cs
@@ -37,7 +37,7 @@ public static class Program
         ShowWindowEvent = new EventWaitHandle(false, EventResetMode.AutoReset, ShowWindowEventName);
 
 #if !WINDOWS_APP_SDK_SELF_CONTAINED
-        Bootstrap.Initialize(0x00010008);
+        Bootstrap.Initialize(0x00020000);
 #endif
         WinRT.ComWrappersSupport.InitializeComWrappers();
 

--- a/csharp/src/SonosStreaming.App/SonosStreaming.App.csproj
+++ b/csharp/src/SonosStreaming.App/SonosStreaming.App.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <RootNamespace>SonosStreaming.App</RootNamespace>
     <AssemblyName>RoomRelay</AssemblyName>
@@ -15,17 +14,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.162">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.2.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/src/SonosStreaming.Core/SonosStreaming.Core.csproj
+++ b/csharp/src/SonosStreaming.Core/SonosStreaming.Core.csproj
@@ -1,16 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <RootNamespace>SonosStreaming.Core</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.162">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/csharp/tests/SonosStreaming.Tests/MockSonosE2E.cs
+++ b/csharp/tests/SonosStreaming.Tests/MockSonosE2E.cs
@@ -136,9 +136,10 @@ public class MockSonosE2E : IDisposable
     [Fact]
     public async Task SonosController_GetVolumeAsync_ReadsCurrentVolume()
     {
+        var ct = TestContext.Current.CancellationToken;
         var device = new SonosDevice("Test", IPAddress.Loopback, (ushort)_port, "uuid:TEST");
 
-        var volume = await new SonosController().GetVolumeAsync(device);
+        var volume = await new SonosController().GetVolumeAsync(device, ct);
 
         volume.Should().Be(37);
     }

--- a/csharp/tests/SonosStreaming.Tests/SonosStreaming.Tests.csproj
+++ b/csharp/tests/SonosStreaming.Tests/SonosStreaming.Tests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <RootNamespace>SonosStreaming.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
-    <PackageReference Include="FsCheck.Xunit" Version="3.0.0" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="3.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/tests/SonosStreaming.Tests/SsdpParserTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/SsdpParserTests.cs
@@ -56,15 +56,16 @@ public class SsdpParserTests
     [Fact]
     public async Task LookupAsync_FetchesDeviceDescriptionFromCustomPort()
     {
+        var ct = TestContext.Current.CancellationToken;
         using var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
         var port = (ushort)((IPEndPoint)listener.LocalEndpoint).Port;
         var serverTask = Task.Run(async () =>
         {
-            using var client = await listener.AcceptTcpClientAsync();
+            using var client = await listener.AcceptTcpClientAsync(ct);
             await using var stream = client.GetStream();
             var buffer = new byte[2048];
-            _ = await stream.ReadAsync(buffer);
+            _ = await stream.ReadAsync(buffer, ct);
 
             var xml = "<?xml version=\"1.0\"?><root><device><friendlyName>Office</friendlyName><UDN>uuid:RINCON_TEST01400</UDN></device></root>";
             var body = Encoding.UTF8.GetBytes(xml);
@@ -72,12 +73,12 @@ public class SsdpParserTests
                 "HTTP/1.1 200 OK\r\n" +
                 $"Content-Length: {body.Length}\r\n" +
                 "Content-Type: text/xml\r\n\r\n");
-            await stream.WriteAsync(header);
-            await stream.WriteAsync(body);
-        });
+            await stream.WriteAsync(header, ct);
+            await stream.WriteAsync(body, ct);
+        }, ct);
 
         using var discovery = new SsdpDiscovery();
-        var device = await discovery.LookupAsync(IPAddress.Loopback, port);
+        var device = await discovery.LookupAsync(IPAddress.Loopback, port, ct);
 
         device.FriendlyName.Should().Be("Office");
         device.Udn.Should().Be("uuid:RINCON_TEST01400");
@@ -89,15 +90,16 @@ public class SsdpParserTests
     [Fact]
     public async Task LookupAsync_RejectsNonSonosUdn()
     {
+        var ct = TestContext.Current.CancellationToken;
         using var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
         var port = (ushort)((IPEndPoint)listener.LocalEndpoint).Port;
         var serverTask = Task.Run(async () =>
         {
-            using var client = await listener.AcceptTcpClientAsync();
+            using var client = await listener.AcceptTcpClientAsync(ct);
             await using var stream = client.GetStream();
             var buffer = new byte[2048];
-            _ = await stream.ReadAsync(buffer);
+            _ = await stream.ReadAsync(buffer, ct);
 
             var xml = "<?xml version=\"1.0\"?><root><device><friendlyName>Hue Bridge</friendlyName><UDN>uuid:SomeOtherDevice-1234</UDN></device></root>";
             var body = Encoding.UTF8.GetBytes(xml);
@@ -105,12 +107,12 @@ public class SsdpParserTests
                 "HTTP/1.1 200 OK\r\n" +
                 $"Content-Length: {body.Length}\r\n" +
                 "Content-Type: text/xml\r\n\r\n");
-            await stream.WriteAsync(header);
-            await stream.WriteAsync(body);
-        });
+            await stream.WriteAsync(header, ct);
+            await stream.WriteAsync(body, ct);
+        }, ct);
 
         using var discovery = new SsdpDiscovery();
-        var act = () => discovery.LookupAsync(IPAddress.Loopback, port);
+        var act = () => discovery.LookupAsync(IPAddress.Loopback, port, ct);
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not a Sonos speaker*");
         await serverTask;
     }

--- a/csharp/tests/SonosStreaming.Tests/StreamServerTests.cs
+++ b/csharp/tests/SonosStreaming.Tests/StreamServerTests.cs
@@ -135,19 +135,20 @@ public class StreamServerTests
     [Fact]
     public async Task PcmRangeRequest_ReturnsRangeNotSatisfiable()
     {
+        var ct = TestContext.Current.CancellationToken;
         var broadcast = new BroadcastChannel<ReadOnlyMemory<byte>>();
         var server = new StreamServer(broadcast, 0, StreamingFormat.WavPcm, IPAddress.Loopback);
         server.Start();
         try
         {
             using var client = new TcpClient();
-            await client.ConnectAsync(IPAddress.Loopback, server.LocalEndPoint.Port);
+            await client.ConnectAsync(IPAddress.Loopback, server.LocalEndPoint.Port, ct);
             await using var stream = client.GetStream();
             var request = Encoding.ASCII.GetBytes($"GET {server.StreamPath} HTTP/1.0\r\nHost: localhost\r\nRange: bytes=1024-\r\n\r\n");
-            await stream.WriteAsync(request);
+            await stream.WriteAsync(request, ct);
 
             var buffer = new byte[512];
-            var read = await stream.ReadAsync(buffer);
+            var read = await stream.ReadAsync(buffer, ct);
             var response = Encoding.ASCII.GetString(buffer, 0, read);
 
             response.Should().StartWith("HTTP/1.0 416 Range Not Satisfiable");


### PR DESCRIPTION
## Summary
- Retarget RoomRelay to .NET 10 and Windows SDK 10.0.26100 while preserving Windows 10 19041 runtime support.
- Upgrade Windows App SDK to 2.0.1, update unpackaged bootstrap, and refresh CI/docs prerequisites.
- Migrate tests to xUnit v3 with FsCheck xUnit v3 and update cancellation-token usage for xUnit analyzers.

## Verification
- dotnet restore SonosStreaming.sln
- dotnet build SonosStreaming.sln -c Release --no-restore -warnaserror
- dotnet test SonosStreaming.sln -c Release --no-build --logger "trx;LogFileName=tests.trx" --results-directory TestResults
- dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained true -p:WindowsAppSDKSelfContained=false -o publish\RoomRelay-v1.0.7
- Startup smoke test passed against Windows App Runtime 2.0.1

## Notes
- Local validation used a repo-local .NET 10 SDK at .dotnet10 because the machine-wide winget SDK registration was stale.
