### PR TITLE
Add no-client Sonos diagnostic

### DIFF
--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -8,10 +8,10 @@
     <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <Version>1.0.8</Version>
-    <FileVersion>1.0.8.0</FileVersion>
-    <AssemblyVersion>1.0.8.0</AssemblyVersion>
-    <InformationalVersion>1.0.8</InformationalVersion>
+    <Version>1.0.9</Version>
+    <FileVersion>1.0.9.0</FileVersion>
+    <AssemblyVersion>1.0.9.0</AssemblyVersion>
+    <InformationalVersion>1.0.9</InformationalVersion>
     <Company>guicn555</Company>
   </PropertyGroup>
 </Project>

--- a/csharp/installer/README.md
+++ b/csharp/installer/README.md
@@ -8,8 +8,8 @@ This folder contains an [Inno Setup](https://jrsoftware.org/isinfo.php) script t
 2. Publish the app variants:
    ```powershell
    cd ..\..\csharp
-   dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained true -p:WindowsAppSDKSelfContained=true -o publish\RoomRelay-v1.0.8-win-x64-full
-   dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained false -p:WindowsAppSDKSelfContained=false -o publish\RoomRelay-v1.0.8-win-x64-light
+   dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained true -p:WindowsAppSDKSelfContained=true -o publish\RoomRelay-v1.0.9-win-x64-full
+   dotnet publish src\SonosStreaming.App -c Release -r win-x64 --self-contained false -p:WindowsAppSDKSelfContained=false -o publish\RoomRelay-v1.0.9-win-x64-light
    ```
 
 ## Build the Installer
@@ -17,12 +17,12 @@ This folder contains an [Inno Setup](https://jrsoftware.org/isinfo.php) script t
 Open `installer.iss` in Inno Setup Compiler (or right-click → **Compile**), or run from command line:
 
 ```powershell
-iscc installer.iss /DPublishDir=RoomRelay-v1.0.8-win-x64-full /DArtifactSuffix=win-x64-full
-iscc installer.iss /DPublishDir=RoomRelay-v1.0.8-win-x64-light /DArtifactSuffix=win-x64-light
+iscc installer.iss /DPublishDir=RoomRelay-v1.0.9-win-x64-full /DArtifactSuffix=win-x64-full
+iscc installer.iss /DPublishDir=RoomRelay-v1.0.9-win-x64-light /DArtifactSuffix=win-x64-light
 ```
 
-The installers `RoomRelay-Setup-1.0.8-win-x64-full.exe` and
-`RoomRelay-Setup-1.0.8-win-x64-light.exe` will be created in `csharp\`.
+The installers `RoomRelay-Setup-1.0.9-win-x64-full.exe` and
+`RoomRelay-Setup-1.0.9-win-x64-light.exe` will be created in `csharp\`.
 
 ## What the Installer Does
 
@@ -35,7 +35,7 @@ The installers `RoomRelay-Setup-1.0.8-win-x64-full.exe` and
 ## Silent Install (Enterprise/Deployment)
 
 ```powershell
-RoomRelay-Setup-1.0.8-win-x64-full.exe /VERYSILENT /NORESTART
+RoomRelay-Setup-1.0.9-win-x64-full.exe /VERYSILENT /NORESTART
 ```
 
 ## Size

--- a/csharp/installer/installer.iss
+++ b/csharp/installer/installer.iss
@@ -3,13 +3,13 @@
 ; Compile with: iscc installer.iss
 
 #define MyAppName "RoomRelay"
-#define MyAppVersion "1.0.8"
+#define MyAppVersion "1.0.9"
 #define MyAppPublisher "guicn555"
 #define MyAppURL "https://github.com/guicn555/RoomRelay"
 #define MyAppExeName "RoomRelay.exe"
 
 #ifndef PublishDir
-#define PublishDir "RoomRelay-v1.0.8-win-x64-full"
+#define PublishDir "RoomRelay-v1.0.9-win-x64-full"
 #endif
 
 #ifndef ArtifactSuffix

--- a/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
+++ b/csharp/src/SonosStreaming.App/ViewModels/MainViewModel.cs
@@ -269,6 +269,7 @@ public sealed partial class MainViewModel : ObservableObject
 
         Pipeline.PumpCrashed += OnPumpCrashed;
         Pipeline.FormatChanged += OnFormatChanged;
+        Pipeline.NoClientConnected += OnNoClientConnected;
         _allowSonosVolumeApply = true;
     }
 
@@ -286,6 +287,18 @@ public sealed partial class MainViewModel : ObservableObject
     partial void OnClientCountChanged(int value)
     {
         OnPropertyChanged(nameof(ClientStatusLabel));
+    }
+
+    private void OnNoClientConnected(object? sender, EventArgs e)
+    {
+        var streamUrl = Pipeline.CurrentStreamUrl ?? "the RoomRelay stream URL";
+        var message = $"The selected Sonos room has not connected to {streamUrl}. Allow RoomRelay through Windows Firewall for private networks, then check that the PC and speaker are on the same reachable LAN/VLAN.";
+        Log.Warning("No Sonos client connected warning shown: {Message}", message);
+
+        if (_dq != null)
+            _dq.TryEnqueue(() => ShowNotification("Speaker Not Connected", message, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Warning));
+        else
+            ShowNotification("Speaker Not Connected", message, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Warning);
     }
 
     partial void OnIsClippingChanged(bool value)

--- a/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
+++ b/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
@@ -66,6 +66,11 @@ public sealed class PipelineRunner : IDisposable
     /// </summary>
     public event EventHandler? FormatChanged;
 
+    /// <summary>
+    /// Raised once when Sonos never opens the HTTP stream after playback starts.
+    /// </summary>
+    public event EventHandler? NoClientConnected;
+
     public PipelineRunner(AppCore core, PipelineOptions? options = null)
     {
         _core = core;
@@ -146,6 +151,8 @@ public sealed class PipelineRunner : IDisposable
 
         _clientCountTask = Task.Run(async () =>
         {
+            var noClientWarningAt = _pipelineStart.AddSeconds(10);
+            var noClientWarningRaised = false;
             while (!token.IsCancellationRequested)
             {
                 try
@@ -156,6 +163,16 @@ public sealed class PipelineRunner : IDisposable
                     {
                         FirstClientAtUtc = DateTime.UtcNow;
                         Log.Information("First Sonos client connected after {Ms:F0} ms", (FirstClientAtUtc.Value - _pipelineStart).TotalMilliseconds);
+                    }
+
+                    if (!noClientWarningRaised && FirstClientAtUtc == null && DateTime.UtcNow >= noClientWarningAt)
+                    {
+                        noClientWarningRaised = true;
+                        Log.Warning("No Sonos client connected after {Ms:F0} ms. The speaker did not fetch {Url}; check Windows Firewall inbound access for RoomRelay, network/VLAN isolation, and that {LocalIp}:8000 is reachable from the speaker.",
+                            (DateTime.UtcNow - _pipelineStart).TotalMilliseconds,
+                            CurrentStreamUrl ?? "the stream URL",
+                            CurrentLocalIp);
+                        NoClientConnected?.Invoke(this, EventArgs.Empty);
                     }
                 }
                 catch (OperationCanceledException) { break; }


### PR DESCRIPTION
## Summary
- Warn the user when the selected Sonos room never opens the RoomRelay HTTP stream after playback starts.
- Log firewall, LAN/VLAN, and stream URL diagnostics for no-client connection failures.
- Bump RoomRelay release metadata and installer docs to v1.0.9.

## Testing
- Not run; PR creation only.