### PR TITLE
Ignore generated release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ csharp/stderr*.txt
 csharp/ffmpeg/
 csharp/publish/
 csharp/release/
+csharp/release-v*/
 csharp/SonosStreaming-Setup-*.exe
 csharp/RoomRelay-Setup-*.exe
+csharp/RoomRelay-v*.zip
+csharp/SHA256SUMS*.txt
 *.log


### PR DESCRIPTION
## Summary
- Ignore generated RoomRelay release ZIPs, checksum files, and versioned release directories.
- Keep local release artifacts out of future commits.

## Release
- Marked `release:none`; this should not publish a GitHub release.

## Testing
- `git check-ignore -v csharp/release-v1.0.9/ csharp/RoomRelay-v1.0.9-win-x64-full.zip csharp/SHA256SUMS-v1.0.9.txt`