### PR TITLE
Add Windows ARM64 release build (1.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,29 +215,50 @@ jobs:
             "/p:InformationalVersion=$version"
           )
 
-          dotnet publish src\SonosStreaming.App\SonosStreaming.App.csproj -c Release -r win-x64 --self-contained true -p:WindowsAppSDKSelfContained=true -o "publish\RoomRelay-v$version-win-x64-full" @versionProps
-          dotnet publish src\SonosStreaming.App\SonosStreaming.App.csproj -c Release -r win-x64 --self-contained false -p:WindowsAppSDKSelfContained=false -o "publish\RoomRelay-v$version-win-x64-light" @versionProps
+          $variants = @(
+            @{ Rid = "win-x64";   SelfContained = $true;  Suffix = "win-x64-full"   },
+            @{ Rid = "win-x64";   SelfContained = $false; Suffix = "win-x64-light"  },
+            @{ Rid = "win-arm64"; SelfContained = $true;  Suffix = "win-arm64-full" },
+            @{ Rid = "win-arm64"; SelfContained = $false; Suffix = "win-arm64-light"}
+          )
+
+          foreach ($v in $variants) {
+            $sc = $v.SelfContained.ToString().ToLowerInvariant()
+            dotnet publish src\SonosStreaming.App\SonosStreaming.App.csproj -c Release -r $v.Rid --self-contained $sc -p:WindowsAppSDKSelfContained=$sc -o "publish\RoomRelay-v$version-$($v.Suffix)" @versionProps
+            if ($LASTEXITCODE -ne 0) { throw "Publish failed for $($v.Suffix)" }
+          }
 
       - name: Build installers
         run: |
           $version = "${{ needs.determine-release.outputs.version }}"
           $iscc = Join-Path ${env:ProgramFiles(x86)} "Inno Setup 6\ISCC.exe"
 
-          & $iscc "installer\installer.iss" "/DMyAppVersion=$version" "/DPublishDir=RoomRelay-v$version-win-x64-full" "/DArtifactSuffix=win-x64-full"
-          & $iscc "installer\installer.iss" "/DMyAppVersion=$version" "/DPublishDir=RoomRelay-v$version-win-x64-light" "/DArtifactSuffix=win-x64-light"
+          $variants = @(
+            @{ Suffix = "win-x64-full";   Arch = "x64"   },
+            @{ Suffix = "win-x64-light";  Arch = "x64"   },
+            @{ Suffix = "win-arm64-full"; Arch = "arm64" },
+            @{ Suffix = "win-arm64-light";Arch = "arm64" }
+          )
+
+          foreach ($v in $variants) {
+            & $iscc "installer\installer.iss" "/DMyAppVersion=$version" "/DPublishDir=RoomRelay-v$version-$($v.Suffix)" "/DArtifactSuffix=$($v.Suffix)" "/DTargetArch=$($v.Arch)"
+            if ($LASTEXITCODE -ne 0) { throw "ISCC failed for $($v.Suffix)" }
+          }
 
       - name: Create ZIP archives and checksums
         run: |
           $version = "${{ needs.determine-release.outputs.version }}"
-          $assets = @(
-            "RoomRelay-v$version-win-x64-full.zip",
-            "RoomRelay-v$version-win-x64-light.zip",
-            "RoomRelay-Setup-$version-win-x64-full.exe",
-            "RoomRelay-Setup-$version-win-x64-light.exe"
-          )
+          $suffixes = @("win-x64-full", "win-x64-light", "win-arm64-full", "win-arm64-light")
 
-          Compress-Archive -Path "publish\RoomRelay-v$version-win-x64-full\*" -DestinationPath $assets[0] -Force
-          Compress-Archive -Path "publish\RoomRelay-v$version-win-x64-light\*" -DestinationPath $assets[1] -Force
+          $assets = @()
+          foreach ($s in $suffixes) {
+            $zip = "RoomRelay-v$version-$s.zip"
+            Compress-Archive -Path "publish\RoomRelay-v$version-$s\*" -DestinationPath $zip -Force
+            $assets += $zip
+          }
+          foreach ($s in $suffixes) {
+            $assets += "RoomRelay-Setup-$version-$s.exe"
+          }
 
           $checksums = foreach ($asset in $assets) {
             $hash = (Get-FileHash -Algorithm SHA256 -Path $asset).Hash.ToLowerInvariant()
@@ -252,8 +273,12 @@ jobs:
           path: |
             csharp/RoomRelay-v${{ needs.determine-release.outputs.version }}-win-x64-full.zip
             csharp/RoomRelay-v${{ needs.determine-release.outputs.version }}-win-x64-light.zip
+            csharp/RoomRelay-v${{ needs.determine-release.outputs.version }}-win-arm64-full.zip
+            csharp/RoomRelay-v${{ needs.determine-release.outputs.version }}-win-arm64-light.zip
             csharp/RoomRelay-Setup-${{ needs.determine-release.outputs.version }}-win-x64-full.exe
             csharp/RoomRelay-Setup-${{ needs.determine-release.outputs.version }}-win-x64-light.exe
+            csharp/RoomRelay-Setup-${{ needs.determine-release.outputs.version }}-win-arm64-full.exe
+            csharp/RoomRelay-Setup-${{ needs.determine-release.outputs.version }}-win-arm64-light.exe
             csharp/SHA256SUMS.txt
           if-no-files-found: error
 
@@ -313,6 +338,7 @@ jobs:
             fi
             echo
             echo "## Assets"
+            echo "- \`win-x64\` artifacts target Intel/AMD 64-bit Windows; \`win-arm64\` artifacts target Windows on ARM (e.g., Snapdragon, Surface Pro X)."
             echo "- Full installer and ZIP include the app and bundled runtime dependencies."
             echo "- Light installer and ZIP require the Windows App Runtime to be installed separately."
           } > release-notes.md

--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@ radio, and background audio where a small network buffer is acceptable.
 
 ## Download
 
-Download the latest release:
+Download the latest release from the [releases page](https://github.com/guicn555/RoomRelay/releases/latest):
 
-- [Windows installer](https://github.com/guicn555/RoomRelay/releases/latest)
-- [Portable/self-contained ZIP](https://github.com/guicn555/RoomRelay/releases/latest)
-- [Checksums](https://github.com/guicn555/RoomRelay/releases/latest)
+- **Windows x64** (Intel/AMD): installer (`RoomRelay-Setup-…-win-x64-full.exe`) or
+  portable ZIP (`RoomRelay-…-win-x64-full.zip`).
+- **Windows on ARM** (Snapdragon, Surface Pro X, etc.): installer
+  (`RoomRelay-Setup-…-win-arm64-full.exe`) or portable ZIP
+  (`RoomRelay-…-win-arm64-full.zip`).
+- A `-light` variant of each is also published; it omits the bundled Windows App
+  Runtime and requires the matching framework package to be installed separately.
+- `SHA256SUMS.txt` lists checksums for every artifact.
 
-The release build bundles the app and .NET runtime. It uses the installed
+The full release build bundles the app and .NET runtime. It uses the installed
 Windows App Runtime framework package on Windows.
 
 ## Why RoomRelay?

--- a/csharp/AGENTS.md
+++ b/csharp/AGENTS.md
@@ -410,9 +410,6 @@ Unit tests use xUnit + FluentAssertions + FsCheck. The e2e test
   and SOAP 500 responses without spinning up real HTTP servers.
 
 ### Low priority
-- **Win2D `Microsoft.Graphics.Canvas.dll` AnyCPU vs x64 warning.**
-  Suppressed by `RuntimeIdentifier=win-x64`.
-
 - **Serilog log path discoverability.** The log lives at
   `%APPDATA%\RoomRelay\app{yyyymmdd}.log` but isn't shown in the
   UI; an "Open log" menu item would help debugging.

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -8,10 +8,10 @@
     <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <Version>1.0.9</Version>
-    <FileVersion>1.0.9.0</FileVersion>
-    <AssemblyVersion>1.0.9.0</AssemblyVersion>
-    <InformationalVersion>1.0.9</InformationalVersion>
+    <Version>1.1.0</Version>
+    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <InformationalVersion>1.1.0</InformationalVersion>
     <Company>guicn555</Company>
   </PropertyGroup>
 </Project>

--- a/csharp/installer/installer.iss
+++ b/csharp/installer/installer.iss
@@ -4,7 +4,7 @@
 
 #define MyAppName "RoomRelay"
 #ifndef MyAppVersion
-#define MyAppVersion "1.0.9"
+#define MyAppVersion "1.1.0"
 #endif
 #define MyAppPublisher "guicn555"
 #define MyAppURL "https://github.com/guicn555/RoomRelay"
@@ -16,6 +16,10 @@
 
 #ifndef ArtifactSuffix
 #define ArtifactSuffix "win-x64-full"
+#endif
+
+#ifndef TargetArch
+#define TargetArch "x64"
 #endif
 
 [Setup]
@@ -36,6 +40,8 @@ Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
 MinVersion=10.0.19041
+ArchitecturesAllowed={#TargetArch}
+ArchitecturesInstallIn64BitMode={#TargetArch}
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/csharp/src/SonosStreaming.App/SonosStreaming.App.csproj
+++ b/csharp/src/SonosStreaming.App/SonosStreaming.App.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SonosStreaming.App</RootNamespace>
     <AssemblyName>RoomRelay</AssemblyName>
     <Product>RoomRelay</Product>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <WindowsPackageType>None</WindowsPackageType>
     <EnableMsixTooling>true</EnableMsixTooling>


### PR DESCRIPTION
## Summary
- Cross-publish a `win-arm64` variant alongside `win-x64` (full + light each), so Windows-on-ARM users (Snapdragon, Surface Pro X) get a native build instead of running x64 under emulation.
- New `TargetArch` define on the Inno Setup script drives `ArchitecturesAllowed` / `ArchitecturesInstallIn64BitMode`. Same `AppId` across architectures, so cross-arch reinstalls upgrade in place.
- Release workflow now loops over four variants and uploads 4 ZIPs + 4 installers + `SHA256SUMS.txt`.
- Bump to **1.1.0** (new supported architecture is a feature; `release:minor` label applied).

Originally requested by a Reddit user.

## Files
- `csharp/src/SonosStreaming.App/SonosStreaming.App.csproj` — singular `<RuntimeIdentifier>` → plural `<RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>`.
- `csharp/installer/installer.iss` — new `TargetArch` define + arch gating.
- `.github/workflows/release.yml` — loop over the 4-variant matrix in publish/installer/zip/upload.
- `README.md` — Download section lists x64 and ARM64 explicitly.
- `csharp/AGENTS.md` — drop stale "Win2D AnyCPU vs x64" low-priority bullet (no longer reproduces with multi-RID config).
- `csharp/Directory.Build.props` + `csharp/installer/installer.iss` — bump version 1.0.9 → 1.1.0 to keep in-repo source of truth aligned with the release.

## Test plan
Local verification on x64 host:
- [x] `dotnet publish -r win-arm64 --self-contained true` builds clean with `-warnaserror`.
- [x] `RoomRelay.exe`, `Microsoft.WindowsAppRuntime.dll`, `Microsoft.Graphics.Canvas.dll` all PE machine `0xAA64` in the ARM64 publish.
- [x] `RoomRelay.exe`, `Microsoft.WindowsAppRuntime.dll`, `Microsoft.Graphics.Canvas.dll` still PE machine `0x8664` in the x64 publish (no regression).
- [x] `ISCC /DTargetArch=arm64` compile succeeds locally.

Post-merge:
- [x] Confirm CI release job produces 4 ZIPs, 4 installers, and `SHA256SUMS.txt` with 8 lines.
- [x] Tag `v1.1.0` is created and pushed by the workflow.
- [x] Smoke test ARM64 build on Windows-on-ARM hardware (waiting on Reddit requester for first field report).