### PR TITLE
Fix pipeline crash on multi-channel audio devices

### DIFF
--- a/csharp/src/SonosStreaming.Core/Audio/PcmFrameTypes.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/PcmFrameTypes.cs
@@ -39,6 +39,51 @@ public sealed class PcmFrameI16
 
 public static class PcmConvert
 {
+    /// <summary>
+    /// Folds a multi-channel frame down to stereo. Returns the frame unchanged
+    /// if it is already stereo. Mono is duplicated to L+R. For N > 2 channels,
+    /// even-indexed channels fold to L and odd-indexed channels fold to R,
+    /// normalised so peak amplitude is preserved.
+    /// </summary>
+    public static PcmFrameF32 DownmixToStereo(PcmFrameF32 frame)
+    {
+        if (frame.Channels == 2) return frame;
+
+        int frameCount = frame.FrameCount;
+        int inCh = frame.Channels;
+        var output = new float[frameCount * 2];
+
+        if (inCh == 1)
+        {
+            for (int f = 0; f < frameCount; f++)
+            {
+                output[f * 2]     = frame.Samples[f];
+                output[f * 2 + 1] = frame.Samples[f];
+            }
+            return new PcmFrameF32(output, frame.SampleRate, 2);
+        }
+
+        // Even-indexed channels (FL, FC, BL, FLC, …) → L
+        // Odd-indexed channels  (FR, LFE, BR, FRC, …) → R
+        int evenCount = (inCh + 1) / 2;
+        int oddCount  = inCh / 2;
+        float scaleL  = 1f / evenCount;
+        float scaleR  = 1f / oddCount;
+        for (int f = 0; f < frameCount; f++)
+        {
+            float l = 0f, r = 0f;
+            int baseIdx = f * inCh;
+            for (int c = 0; c < inCh; c++)
+            {
+                if ((c & 1) == 0) l += frame.Samples[baseIdx + c];
+                else              r += frame.Samples[baseIdx + c];
+            }
+            output[f * 2]     = l * scaleL;
+            output[f * 2 + 1] = r * scaleR;
+        }
+        return new PcmFrameF32(output, frame.SampleRate, 2);
+    }
+
     public static void F32ToI16(ReadOnlySpan<float> input, List<short> output)
     {
         output.Clear();

--- a/csharp/src/SonosStreaming.Core/Audio/PcmFrameTypes.cs
+++ b/csharp/src/SonosStreaming.Core/Audio/PcmFrameTypes.cs
@@ -63,23 +63,38 @@ public static class PcmConvert
             return new PcmFrameF32(output, frame.SampleRate, 2);
         }
 
-        // Even-indexed channels (FL, FC, BL, FLC, …) → L
-        // Odd-indexed channels  (FR, LFE, BR, FRC, …) → R
-        int evenCount = (inCh + 1) / 2;
-        int oddCount  = inCh / 2;
-        float scaleL  = 1f / evenCount;
-        float scaleR  = 1f / oddCount;
+        // WAVEFORMATEXTENSIBLE standard layouts (KSAUDIO_SPEAKER_5POINT1 / 7POINT1):
+        //   5.1: FL FR FC LFE BL BR
+        //   7.1: FL FR FC LFE BL BR SL SR
+        // ITU-R BS.775 style: FC and LFE split equally to L+R, surrounds at -3 dB.
+        const float c3dB = 0.7071f;
         for (int f = 0; f < frameCount; f++)
         {
-            float l = 0f, r = 0f;
-            int baseIdx = f * inCh;
-            for (int c = 0; c < inCh; c++)
+            int b = f * inCh;
+            float l, r;
+            switch (inCh)
             {
-                if ((c & 1) == 0) l += frame.Samples[baseIdx + c];
-                else              r += frame.Samples[baseIdx + c];
+                case 6: // 5.1
+                    l = frame.Samples[b]   + c3dB * frame.Samples[b+2] + c3dB * frame.Samples[b+4] + frame.Samples[b+3];
+                    r = frame.Samples[b+1] + c3dB * frame.Samples[b+2] + c3dB * frame.Samples[b+5] + frame.Samples[b+3];
+                    break;
+                case 8: // 7.1
+                    l = frame.Samples[b]   + c3dB * frame.Samples[b+2] + c3dB * frame.Samples[b+4] + c3dB * frame.Samples[b+6] + frame.Samples[b+3];
+                    r = frame.Samples[b+1] + c3dB * frame.Samples[b+2] + c3dB * frame.Samples[b+5] + c3dB * frame.Samples[b+7] + frame.Samples[b+3];
+                    break;
+                default: // generic even/odd fallback for unusual layouts
+                    l = 0f; r = 0f;
+                    for (int ch = 0; ch < inCh; ch++)
+                    {
+                        if ((ch & 1) == 0) l += frame.Samples[b + ch];
+                        else               r += frame.Samples[b + ch];
+                    }
+                    l /= (inCh + 1) / 2;
+                    r /= inCh / 2;
+                    break;
             }
-            output[f * 2]     = l * scaleL;
-            output[f * 2 + 1] = r * scaleR;
+            output[f * 2]     = l;
+            output[f * 2 + 1] = r;
         }
         return new PcmFrameF32(output, frame.SampleRate, 2);
     }

--- a/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
+++ b/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
@@ -280,7 +280,7 @@ public sealed class PipelineRunner : IDisposable
             var mix = CurrentMixFormat ?? throw new InvalidOperationException("Pipeline started without a capture format.");
             if (mix.Channels > 2)
                 Log.Information("Capture is {Ch}-channel; will downmix to stereo before encode", mix.Channels);
-            ushort resamplerChannels = mix.Channels > 2 ? (ushort)2 : mix.Channels;
+            ushort resamplerChannels = mix.Channels != 2 ? (ushort)2 : mix.Channels;
             _resampler = new Resampler(mix.SampleRate, resamplerChannels);
             _encoder = Format switch
             {
@@ -325,7 +325,7 @@ public sealed class PipelineRunner : IDisposable
                 UpdateClipping(samples);
                 _vuMeter.Process(samples, frame.Channels);
 
-                var resamplerInput = frame.Channels > 2 ? PcmConvert.DownmixToStereo(frame) : frame;
+                var resamplerInput = frame.Channels != 2 ? PcmConvert.DownmixToStereo(frame) : frame;
                 var i16Frame = _resampler.Process(resamplerInput);
                 _encoder.Encode(i16Frame);
                 var chunk = _encoder.FlushChunk();

--- a/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
+++ b/csharp/src/SonosStreaming.Core/Pipeline/PipelineRunner.cs
@@ -278,7 +278,10 @@ public sealed class PipelineRunner : IDisposable
         try
         {
             var mix = CurrentMixFormat ?? throw new InvalidOperationException("Pipeline started without a capture format.");
-            _resampler = new Resampler(mix.SampleRate, mix.Channels);
+            if (mix.Channels > 2)
+                Log.Information("Capture is {Ch}-channel; will downmix to stereo before encode", mix.Channels);
+            ushort resamplerChannels = mix.Channels > 2 ? (ushort)2 : mix.Channels;
+            _resampler = new Resampler(mix.SampleRate, resamplerChannels);
             _encoder = Format switch
             {
                 StreamingFormat.Aac128 => new MfAacEncoder(128_000),
@@ -322,7 +325,8 @@ public sealed class PipelineRunner : IDisposable
                 UpdateClipping(samples);
                 _vuMeter.Process(samples, frame.Channels);
 
-                var i16Frame = _resampler.Process(frame);
+                var resamplerInput = frame.Channels > 2 ? PcmConvert.DownmixToStereo(frame) : frame;
+                var i16Frame = _resampler.Process(resamplerInput);
                 _encoder.Encode(i16Frame);
                 var chunk = _encoder.FlushChunk();
                 if (!chunk.IsEmpty)


### PR DESCRIPTION
﻿Whole-system capture crashes on devices running in 5.1 or 7.1 mode because `Resampler` rejects any input that is not stereo.

Adds `PcmConvert.DownmixToStereo` which folds an N-channel frame to stereo before it reaches the resampler. Even-indexed channels (FL, FC, BL, FLC) sum into L and odd-indexed channels (FR, LFE, BR, FRC) sum into R, each normalised by the number of channels on that side so amplitude is preserved. Mono is duplicated to both channels. The DSP stages upstream still operate on the full multi-channel frame as before.

Tested on a system where the default render endpoint reports 8 channels (7.1 surround). The pipeline previously crashed on every start attempt and now streams without issue.
